### PR TITLE
Rename plcontainer_read_config() to more accurate plcontainer_show_co…

### DIFF
--- a/management/bin/plcontainer-config
+++ b/management/bin/plcontainer-config
@@ -309,7 +309,7 @@ def main():
                     new_config = True
 
         if new_config:
-            logger.info('Configuration has changed. Run "select * from plcontainer_read_config()" in open sessions.' +
+            logger.info('Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions.' +
                         ' New sessions will get new configuration automatically')
 
     except Exception, e:

--- a/management/sql/plcontainer_install.sql
+++ b/management/sql/plcontainer_install.sql
@@ -8,26 +8,30 @@ CREATE TRUSTED LANGUAGE plcontainer HANDLER plcontainer_call_handler;
 
 -- Defining container configuration management functions
 
-CREATE TYPE plcontainer_status AS (
-    segment_id int,
-    status varchar
-);
-
-CREATE OR REPLACE FUNCTION plcontainer_read_local_config(verbose bool) RETURNS text
-AS '$libdir/plcontainer', 'read_plcontainer_config'
+CREATE OR REPLACE FUNCTION plcontainer_show_local_config() RETURNS text
+AS '$libdir/plcontainer', 'show_plcontainer_config'
 LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION plcontainer_read_config(verbose bool) RETURNS SETOF plcontainer_status AS $$
-    select gp_segment_id, plcontainer_read_local_config($1)
+CREATE OR REPLACE FUNCTION plcontainer_refresh_local_config(verbose bool) RETURNS text
+AS '$libdir/plcontainer', 'refresh_plcontainer_config'
+LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE VIEW plcontainer_show_config as
+    select gp_segment_id, plcontainer_show_local_config()
         from (
             select gp_segment_id
                 from gp_dist_random('pg_namespace')
                 group by 1
             ) as segments
     union all
-    select -1, plcontainer_read_local_config($1);
-$$ LANGUAGE SQL VOLATILE;
+    select -1, plcontainer_show_local_config();
 
-CREATE OR REPLACE FUNCTION plcontainer_read_config() RETURNS SETOF plcontainer_status AS $$
-    select plcontainer_read_config(false);
-$$ LANGUAGE SQL VOLATILE;
+CREATE OR REPLACE VIEW plcontainer_refresh_config as
+    select gp_segment_id, plcontainer_refresh_local_config(false)
+        from (
+            select gp_segment_id
+                from gp_dist_random('pg_namespace')
+                group by 1
+            ) as segments
+    union all
+    select -1, plcontainer_refresh_local_config(false);

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -37,8 +37,8 @@ typedef struct plcContainer {
 } plcContainer;
 
 /* entrypoint for all plcontainer procedures */
-Datum read_plcontainer_config(PG_FUNCTION_ARGS);
-int plc_read_container_config(bool verbose);
+Datum refresh_plcontainer_config(PG_FUNCTION_ARGS);
+Datum show_plcontainer_config(PG_FUNCTION_ARGS);
 plcContainer *plc_get_container_config(char *name);
 char *get_sharing_options(plcContainer *cont);
 

--- a/tests/expected/plcontainer_install.out
+++ b/tests/expected/plcontainer_install.out
@@ -4,23 +4,27 @@ RETURNS LANGUAGE_HANDLER
 AS '$libdir/plcontainer' LANGUAGE C;
 CREATE TRUSTED LANGUAGE plcontainer HANDLER plcontainer_call_handler;
 -- Defining container configuration management functions
-CREATE TYPE plcontainer_status AS (
-    segment_id int,
-    status varchar
-);
-CREATE OR REPLACE FUNCTION plcontainer_read_local_config(verbose bool) RETURNS text
-AS '$libdir/plcontainer', 'read_plcontainer_config'
+CREATE OR REPLACE FUNCTION plcontainer_show_local_config() RETURNS text
+AS '$libdir/plcontainer', 'show_plcontainer_config'
 LANGUAGE C VOLATILE;
-CREATE OR REPLACE FUNCTION plcontainer_read_config(verbose bool) RETURNS SETOF plcontainer_status AS $$
-    select gp_segment_id, plcontainer_read_local_config($1)
+CREATE OR REPLACE FUNCTION plcontainer_refresh_local_config(verbose bool) RETURNS text
+AS '$libdir/plcontainer', 'refresh_plcontainer_config'
+LANGUAGE C VOLATILE;
+CREATE OR REPLACE VIEW plcontainer_show_config as
+    select gp_segment_id, plcontainer_show_local_config()
         from (
             select gp_segment_id
                 from gp_dist_random('pg_namespace')
                 group by 1
             ) as segments
     union all
-    select -1, plcontainer_read_local_config($1);
-$$ LANGUAGE SQL VOLATILE;
-CREATE OR REPLACE FUNCTION plcontainer_read_config() RETURNS SETOF plcontainer_status AS $$
-    select plcontainer_read_config(false);
-$$ LANGUAGE SQL VOLATILE;
+    select -1, plcontainer_show_local_config();
+CREATE OR REPLACE VIEW plcontainer_refresh_config as
+    select gp_segment_id, plcontainer_refresh_local_config(false)
+        from (
+            select gp_segment_id
+                from gp_dist_random('pg_namespace')
+                group by 1
+            ) as segments
+    union all
+    select -1, plcontainer_refresh_local_config(false);


### PR DESCRIPTION
…nfig() and plcontainer_refresh_config()

This also changes from sql function to view since the sql function outputs a lot of annoying message like:

CONTEXT:  SQL function "plcontainer_read_config" statement 1