### PR TITLE
Use exit() instead of abort() in client so that atxit() could be used.

### DIFF
--- a/src/common/comm_utils.h
+++ b/src/common/comm_utils.h
@@ -78,7 +78,7 @@ interpreted as representing official policies, either expressed or implied, of t
             fprintf(out, fmt, ##__VA_ARGS__); \
             fprintf(out, "\n");               \
             if (lvl >= ERROR) {               \
-                abort();                      \
+                exit(1);                      \
             }                                 \
         } while (0)
     #define pmalloc malloc


### PR DESCRIPTION
We will want some callbacks registered in atexit().

By now, we do not use fine-grained level handling code in gp/pg;
we just simple call exit() for level >= ERROR. We could allow
abort() if needed in the future.