### PR TITLE
Fix make failed after make clients due to common objects not cleaned.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ VERSION
 *.gppkg
 /package/*.yml
 /concourse/secrets/
-clients_timestamp
+src/common/clients_timestamp

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ VERSION
 *.gppkg
 /package/*.yml
 /concourse/secrets/
+clients_timestamp

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ include release.mk
 
 # Directories
 SRCDIR = ./src
+COMMONDIR = ./src/common
 MGMTDIR = ./management
 PYCLIENTDIR = src/pyclient/bin
 RCLIENTDIR = src/rclient/bin
@@ -97,15 +98,15 @@ installcheck:
 clients:
 	$(MAKE) -C $(SRCDIR)/pyclient
 	$(MAKE) -C $(SRCDIR)/rclient
-	touch clients_timestamp
+	touch $(COMMONDIR)/clients_timestamp
 
 all-lib: check-clients-make
 	@echo "Build PL/Container Done."
 
 .PHONY: check-clients-make
 check-clients-make:
-	if [ -f clients_timestamp ]; then \
-	    rm clients_timestamp && $(MAKE) clean ; \
+	if [ -f $(COMMONDIR)/clients_timestamp ]; then \
+	    rm $(COMMONDIR)/clients_timestamp && $(MAKE) clean ; \
 	fi
 
 .PHONY: clean-clients

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,9 @@ endif
 
 all: all-lib
 
-install: all clients installdirs install-lib install-extra install-clients
+install: installdirs install-lib install-extra install-clients
+
+clean: clean-clients
 
 installdirs: installdirs-lib
 	$(MKDIR_P) '$(DESTDIR)$(bindir)'
@@ -95,3 +97,18 @@ installcheck:
 clients:
 	$(MAKE) -C $(SRCDIR)/pyclient
 	$(MAKE) -C $(SRCDIR)/rclient
+	touch clients_timestamp
+
+all-lib: check-clients-make
+	@echo "Build PL/Container Done."
+
+.PHONY: check-clients-make
+check-clients-make:
+	if [ -f clients_timestamp ]; then \
+	    rm clients_timestamp && $(MAKE) clean ; \
+	fi
+
+.PHONY: clean-clients
+clean-clients:
+	$(MAKE) -C $(SRCDIR)/pyclient clean
+	$(MAKE) -C $(SRCDIR)/rclient clean


### PR DESCRIPTION
Add clean-clients target to enable clean clients object files when 'make clean'.

Update rclient to latest commit.