### PR TITLE
Add tests for network connection after unix domain socket connection is default

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -54,12 +54,14 @@ def parseargs():
                         " file or docker image url")
     config_parser.add_argument("-v", "--volume", dest="shared", action="append",help="Bind mount a volume, can work with multiple volumes" +
                         " format: HOST:CONTAINER:[rw|ro]")
+    config_parser.add_argument("-y","--yes", action='store_true', help="Default yes to confirm step in configure.")
     single_option = config_parser.add_mutually_exclusive_group()
-    single_option.add_argument("-e", "--editor", dest="editor", default="vi", help="Editor to use")
+    single_option.add_argument("-e", "--editor", dest="editor", help="Editor to use")
     single_option.add_argument('--reset', action='store_true', help='Reset the configuration file to default')
     single_option.add_argument("--restore", action="store_true", help="Restore the previous version of PL/Container configuration")
     single_option.add_argument("--cleanup", action="store_true", help="Remove all the backup files for PL/Container")
     single_option.add_argument('-s', '--show', action='store_true', help='Show the contents of configuration file without changing it')
+    single_option.add_argument("-f", "--file", dest="conf_file", help="Overwrite plcontainer configurations with xml file directly")
 
     # for install
     install_parser.add_argument("-i", "--image", dest="image", help="Configure container image location, support Tar.gz image" +
@@ -519,13 +521,22 @@ def main():
         if options.subparser_name == "configure" and options.restore:
             logger.info('Getting list of configuration backups in %s:%s...' % (remote_host, remote_dir))
             filename = get_last_backup(pool, remote_host, remote_dir, PLCONTAINER_CONFIG_FILE)
-            if filename and userinput.ask_yesno(None, "Continue restoring the backup configuration '%s'?" % filename, 'N'):
+            if filename and ( options.yes or userinput.ask_yesno(None, "Continue restoring the backup configuration '%s'?" % filename, 'N') ):
                 pool = WorkerPool(PL_BATCH_SIZE)
                 logger.info('Distributing file %s to all locations...' % PLCONTAINER_CONFIG_FILE)
                 distribute_file(pool, tmp_file, PLCONTAINER_CONFIG_FILE, gpdb_locations)
                 logger.info('Cleaning up old backup file...')
                 remove_files(pool, gpdb_locations, os.path.basename(filename))
                 new_config = True
+
+        if options.subparser_name == "configure" and options.conf_file:
+            logger.info('Preparing the worker pool...')
+            pool = WorkerPool(PL_BATCH_SIZE)
+            logger.info('Backing up file %s on all hosts...' % PLCONTAINER_CONFIG_FILE)
+            backup_file(pool, gpdb_locations, PLCONTAINER_CONFIG_FILE)
+            logger.info('Distributing file %s to all locations...' % options.conf_file)
+            distribute_file(pool, options.conf_file, PLCONTAINER_CONFIG_FILE, gpdb_locations)
+            new_config = True
 
         if options.name and options.subparser_name == "configure":
             elements = get_conf_elements(options)
@@ -547,14 +558,6 @@ def main():
             logger.info('Distributing file %s to all locations...' % PLCONTAINER_CONFIG_FILE)
             distribute_file(pool, tmp_file, PLCONTAINER_CONFIG_FILE, gpdb_locations)
             new_config = True
-
-
-        if options.subparser_name == "configure" and options.restore:
-            if userinput.ask_yesno(None, "Are you sure want to clean up the PL/Container backup configurations?", 'N'):
-                logger.info('Preparing the worker pool...')
-                pool = WorkerPool(PL_BATCH_SIZE)
-                logger.info('Cleaning up old backup files...')
-                remove_files(pool, gpdb_locations, '.' + PLCONTAINER_CONFIG_FILE + '.bak*')
 
         if options.subparser_name == "configure" and options.editor and not options.name:
             changed = edit_file(tmp_file, options.editor)

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -59,7 +59,6 @@ def parseargs():
     single_option.add_argument("-e", "--editor", dest="editor", help="Editor to use")
     single_option.add_argument('--reset', action='store_true', help='Reset the configuration file to default')
     single_option.add_argument("--restore", action="store_true", help="Restore the previous version of PL/Container configuration")
-    single_option.add_argument("--cleanup", action="store_true", help="Remove all the backup files for PL/Container")
     single_option.add_argument('-s', '--show', action='store_true', help='Show the contents of configuration file without changing it')
     single_option.add_argument("-f", "--file", dest="conf_file", help="Overwrite plcontainer configurations with xml file directly")
 
@@ -524,7 +523,7 @@ def main():
             if filename and ( options.yes or userinput.ask_yesno(None, "Continue restoring the backup configuration '%s'?" % filename, 'N') ):
                 pool = WorkerPool(PL_BATCH_SIZE)
                 logger.info('Distributing file %s to all locations...' % PLCONTAINER_CONFIG_FILE)
-                distribute_file(pool, tmp_file, PLCONTAINER_CONFIG_FILE, gpdb_locations)
+                distribute_file(pool, filename, PLCONTAINER_CONFIG_FILE, gpdb_locations)
                 logger.info('Cleaning up old backup file...')
                 remove_files(pool, gpdb_locations, os.path.basename(filename))
                 new_config = True

--- a/package/gppkg.mk
+++ b/package/gppkg.mk
@@ -6,37 +6,6 @@ GP_VERSION_NUM := $(GP_MAJORVERSION)
 MAJOR_OS=$(shell cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*// | awk -F '.' '{print $$1}' )
 ARCH=$(shell uname -p)
 
-# e.g. 
-# postgis-1.0-1-x86_64.rpm
-# Quite a few assumptions about the semantics of the associated RPM spec file:
-#   * Most importantly, from the use of RPM_NAME below, building postgis-*.rpm will require a postgis.spec,
-#     in the current working directory.
-#   * RPMs must disable AutoReq, as gppkg RPM database will lack knowledge of system's libraries
-#   * RPMs with shell commands in hooks must "Provide" /bin/sh, as a hack, for the same reason as the AutoReq issue
-#   * --buildroot must requires an absolute path. I think we cd into %{buildroot} for %install. I think we might also
-#     step into %{buildroot} again for %files. So, relative paths cause "file not found" errors.
-#
-# Sample spec. file
-# Summary:        Geos library
-# License:        LGPL
-# Name:           geos
-# Version:        %{geos_ver}
-# Release:        %{geos_rel}
-# Group:          Development/Tools
-# Prefix:         /temp
-# AutoReq:        no
-# AutoProv:       no
-# Provides:       geos = %{geos_ver}
-#
-# %description
-# The Geos module provides geometric library which is used by PostGIS.
-#
-# %install
-# mkdir -p %{buildroot}/temp/lib
-# cp -rf %{geos_dir}/lib/libgeos* %{buildroot}/temp/lib/
-#
-# %files
-# /temp
 RPM_ARGS=$(subst -, ,$*)
 RPM_NAME=$(word 1,$(RPM_ARGS))
 PWD=$(shell pwd)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,28 +1,25 @@
 #------------------------------------------------------------------------------
-#
 # 
-# Copyright (c) 2016, Pivotal.
+# Copyright (c) 2016-Present Pivotal Software, Inc
 #
 #------------------------------------------------------------------------------
- 
 
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB) --init-file=./init_file
 
+REGRESS_BASIC = plcontainer_install plcontainer_schema
 # R Regression Tests
-REGRESS_R = plcontainer_function_r plcontainer_function_r_gpdb5 \
-		    plcontainer_test_r plcontainer_test_r_gpdb5
+REGRESS_R = plcontainer_function_r plcontainer_function_r_gpdb5
+REGRESS_R_TESTS = plcontainer_test_r plcontainer_test_r_gpdb5
 
 # Python Regression Tests
-REGRESS_PYTHON = plcontainer_function_python plcontainer_function_python_gpdb5 \
-				 plcontainer_test_python plcontainer_test_python_gpdb5 \
-				 plcontainer_test_anaconda \
+REGRESS_PYTHON = plcontainer_function_python plcontainer_function_python_gpdb5
+REGRESS_PYTHON_TESTS = plcontainer_test_python plcontainer_test_python_gpdb5 plcontainer_function_python_network
 
 # Regression Tests for GPDB5
-REGRESS_GPDB5_OLD = plcontainer_install plcontainer_schema $(REGRESS_PYTHON) $(REGRESS_R)
-REGRESS_GPDB5 = plcontainer_install plcontainer_schema plcontainer_function_python plcontainer_function_python_gpdb5 plcontainer_function_r plcontainer_function_r_gpdb5
+REGRESS_GPDB5 = $(REGRESS_BASIC) $(REGRESS_R) $(REGRESS_PYTHON) $(REGRESS_PYTHON_TESTS)
 
 PSQLDIR = $(bindir)
 

--- a/tests/expected/plcontainer_function_python_network.out
+++ b/tests/expected/plcontainer_function_python_network.out
@@ -1,0 +1,55 @@
+\! plcontainer configure -f $(pwd)/plcontainer_configuration_test.xml -y
+drop table if exists test_python_network;
+NOTICE:  table "test_python_network" does not exist, skipping
+create table test_python_network(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_python_network select generate_series(0,10);
+create or replace function python_network_test1(i integer) returns integer as $$
+#container: plc_python_network
+return i + 1024
+$$ language plcontainer;
+create or replace function python_network_test2() returns integer as $$
+#container: plc_python_network
+return 1024
+$$ language plcontainer;
+select python_network_test1(i) from test_python_network;
+ python_network_test1 
+----------------------
+                 1024
+                 1025
+                 1026
+                 1027
+                 1028
+                 1029
+                 1030
+                 1031
+                 1032
+                 1033
+                 1034
+(11 rows)
+
+select python_network_test2() from test_python_network;
+ python_network_test2 
+----------------------
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+                 1024
+(11 rows)
+
+\! plcontainer configure --restore -y
+select * from plcontainer_refresh_config;
+ gp_segment_id | plcontainer_refresh_local_config 
+---------------+----------------------------------
+             0 | ok
+            -1 | ok
+(2 rows)
+

--- a/tests/init_file
+++ b/tests/init_file
@@ -5,7 +5,8 @@
 -- start_matchignore
 # match ignore docker api WARNING message
 m/^WARNING:  Docker API.*/
-
+# match plcontainer command outputs: startswith timestamp: 20170906:14:06:03
+m/^[0-9]{8}:[0-9]{2}:[0-9]{2}:[0-9]{2}.*/
 -- end_matchignore
 -- start_matchsubs
 m/ls: cannot access '.*'.*/

--- a/tests/plcontainer_configuration_test.xml
+++ b/tests/plcontainer_configuration_test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+
+<configuration>
+
+    <!--
+        Structure of the configuration is following:
+        1. Each container is defined within a single <container> tag
+        2. "name" - container name that can be referenced in database creating the
+            function in PL/Container language. Might not match the container name
+            in Docker. Mandatory field
+        3. "image" - container image in Docker, used for starting and stopping
+            the containers. Mandatory field
+        4. "command" - command used to start the client process inside of the
+            container. Mandatory field
+        5. "memory_mb" - container memory limit in MB. Optional. When not set,
+            container can usilize all the available OS memory
+        6. "shared_directory" - a series of tags, each one defines a single
+            directory shared between host and container. Optional
+        7. "use_network" - set to "yes" or "no" to specify whether use tcp or ipc
+            for communication between gpdb process and container process. Optional.
+            By default, we set "no".
+        All the container names not manually defined in this file will not be
+        available for use by endusers in PL/Container
+    -->
+    <container>
+        <name>plc_python_network</name>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient</command>
+        <shared_directory host="/usr/local/greenplum-db-devel/bin/pyclient" container="/clientdir" access="ro"/>
+        <memory_mb>128</memory_mb>
+        <use_network>yes</use_network>
+    </container>
+
+</configuration>

--- a/tests/sql/plcontainer_function_python_network.sql
+++ b/tests/sql/plcontainer_function_python_network.sql
@@ -1,0 +1,23 @@
+\! plcontainer configure -f $(pwd)/plcontainer_configuration_test.xml -y
+
+drop table if exists test_python_network;
+
+create table test_python_network(i int);
+insert into test_python_network select generate_series(0,10);
+
+create or replace function python_network_test1(i integer) returns integer as $$
+#container: plc_python_network
+return i + 1024
+$$ language plcontainer;
+
+create or replace function python_network_test2() returns integer as $$
+#container: plc_python_network
+return 1024
+$$ language plcontainer;
+
+select python_network_test1(i) from test_python_network;
+select python_network_test2() from test_python_network;
+
+\! plcontainer configure --restore -y
+
+select * from plcontainer_refresh_config;


### PR DESCRIPTION
1. add tests and expected out, test configuration file
2. add plcontainer configure -f option to overwrite configuration use file directly, -y for default yes to userinput
3. remove duplicate restore option process block, remove configure -e default value "vi" since -e option is in the mutually exclusive group with other options, otherwise users will be brought to unnecessary edit file if they run restore or cleanup
4. organize tests in Makefile to include the tests new added.
5. remove unused lines.