### PR TITLE
Fix issues of function test on centos

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -279,7 +279,6 @@ jobs:
   plan:
   - aggregate:
     - get: bin_gpdb_centos6
-      trigger: true
     - get: gpdb_src
     - get: plcontainer_src
       trigger: true
@@ -303,6 +302,7 @@ jobs:
     - get: bin_gpdb_centos7
     - get: gpdb_src
     - get: plcontainer_src
+      trigger: true
     - get: centos-gpdb-dev-7
     - get: plr
       resource: plr_gpdb5_centos7_build

--- a/concourse/scripts/docker_install.sh
+++ b/concourse/scripts/docker_install.sh
@@ -21,6 +21,8 @@ install_docker() {
            sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo; \
            sudo yum makecache fast; \
            sudo yum install -y docker-ce; \
+           sudo yum install -y cpan; \
+           sudo yum install -y perl-Module-CoreList; \
            sudo systemctl start docker; \
            sudo groupadd docker; \
            sudo chown root:docker /var/run/docker.sock; \

--- a/concourse/scripts/run_plcontainer.sh
+++ b/concourse/scripts/run_plcontainer.sh
@@ -17,7 +17,7 @@ ssh mdw "bash -c \" \
 set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
-plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \
+plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz -c pivotaldata/plcontainer_python_shared:devel; \
 gpstop -arf
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 pushd plcontainer_src/tests; \

--- a/concourse/scripts/run_plcontainer.sh
+++ b/concourse/scripts/run_plcontainer.sh
@@ -18,7 +18,7 @@ set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \
-
+gpstop -arf
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 pushd plcontainer_src/tests; \
 make tests; \

--- a/concourse/scripts/run_plcontainer.sh
+++ b/concourse/scripts/run_plcontainer.sh
@@ -5,6 +5,7 @@ set -eox pipefail
 scp -r plcontainer_gpdb_build mdw:/tmp/
 scp -r plcontainer_src mdw:~/
 ssh mdw "bash -c \" \
+set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 gppkg -i /tmp/plcontainer_gpdb_build/plcontainer-concourse-centos*.gppkg; \
@@ -13,6 +14,7 @@ gppkg -i /tmp/plcontainer_gpdb_build/plcontainer-concourse-centos*.gppkg; \
 scp -r plcontainer_client_docker_image/plcontainer-devel-images.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
 
 ssh mdw "bash -c \" \
+set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \

--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -6,6 +6,7 @@ scp -r plcontainer_gpdb_build mdw:/tmp/
 scp -r plcontainer_src mdw:~/
 
 ssh mdw "bash -c \" \
+set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 gppkg -i plcontainer_gpdb_build/plcontainer-concourse-centos6.gppkg; \
@@ -14,6 +15,7 @@ gppkg -i plcontainer_gpdb_build/plcontainer-concourse-centos6.gppkg; \
 scp -r plcontainer_client_docker_image/plcontainer-devel-images.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
 
 ssh mdw "bash -c \" \
+set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \

--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -18,7 +18,7 @@ ssh mdw "bash -c \" \
 set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
-plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \
+plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz -c pivotaldata/plcontainer_python_shared:devel; \
 gpstop -arf
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 psql -d postgres -f plcontainer_src/concourse/scripts/function_setup.sql; \

--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -19,7 +19,7 @@ set -eox pipefail; \
 export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer install -n plc_python_shared -i /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-devel-images.tar.gz; \
-
+gpstop -arf
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 psql -d postgres -f plcontainer_src/concourse/scripts/function_setup.sql; \
 psql -d postgres -f plcontainer_src/concourse/scripts/perf_prepare1.sql; \

--- a/dockerfiles/python/centos7/ds/install_python.sh
+++ b/dockerfiles/python/centos7/ds/install_python.sh
@@ -1,5 +1,5 @@
 pushd /opt/ds
-rpm2cpio DataSciencePython-*.x86_64.rpm| cpio -div
+rpm2cpio DataSciencePython-*.x86_64.rpm| cpio -di
 mv temp/ext/DataSciencePython/* ./
 popd
 

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -65,7 +65,8 @@ def parseargs():
     # for install
     install_parser.add_argument("-i", "--image", dest="image", help="Configure container image location, support Tar.gz image" +
                         " file or docker image url")
-    install_parser.add_argument("-n", "--name", dest="name", help="Configure container image name")
+    install_parser.add_argument("-n", "--name", dest="name", help="Configure plcontainer type name")
+    install_parser.add_argument("-c", "--imagename", dest="imagename", help="Configure container image name")
     install_parser.add_argument("-v", "--volume", dest="shared", action="append",help="Bind mount a volume, can work with multiple volumes" +
                         " format: HOST:CONTAINER:[rw|ro]")                    
 
@@ -156,8 +157,17 @@ def install_images(options, pool, hosts):
         logger.info('Loading image on all hosts...')
         docker_load_cmd = " ".join(["docker load -i ", dest])
         dockerUrl = remote_cmd(pool, docker_load_cmd, hosts)
-        # the returned format is "Loaded image: image:tag"
-        return dockerUrl.split(":", 1)[1]
+        tag=""
+        if not dockerUrl:
+            if not options.imagename:
+                logger.error("Old Dokcer verion need to specify image name by -c option")
+                raise Exception("Failed to get image name")
+            else:
+                tag = options.imagename
+        else:
+            # the returned format is "Loaded image: image:tag"
+            tag = dockerUrl.split(":", 1)[1]
+        return tag
 
     except Exception, ex:
         raise(ex)

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -586,7 +586,7 @@ def main():
     except Exception, ex:
         logger.fatal("%s failed. (Reason='%s') exiting..." % (execname, ex))
         if options.verbose:
-            logger.exception(e)
+            logger.exception(ex)
 
     finally:
         if tmp_file:

--- a/tests/expected/plcontainer_function_python.out
+++ b/tests/expected/plcontainer_function_python.out
@@ -1,67 +1,67 @@
 CREATE OR REPLACE FUNCTION pylog100() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.log10(100)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylog(a integer, b integer) RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.log(a, b)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybool(b bool) RETURNS bool AS $$
-# container: plc_python
+# container: plc_python_shared
 return b
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyint(i int2) RETURNS int2 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+1
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyint(i int4) RETURNS int4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+2
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyint(i int8) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+3
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyfloat(f float4) RETURNS float4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return f+1
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyfloat(f float8) RETURNS float8 AS $$
-# container: plc_python
+# container: plc_python_shared
 return f+2
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pynumeric(n numeric) RETURNS numeric AS $$
-# container: plc_python
+# container: plc_python_shared
 return n+3.0
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytimestamp(t timestamp) RETURNS timestamp AS $$
-# container: plc_python
+# container: plc_python_shared
 return t
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytimestamptz(t timestamptz) RETURNS timestamptz AS $$
-# container: plc_python
+# container: plc_python_shared
 return t
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytext(t text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return t+'bar'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybytea(r bytea) RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybytea2() RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return None
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybytea3() RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return ''
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyintarr(arr int8[]) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 def recsum(obj):
     s = 0
     if type(obj) is list:
@@ -75,7 +75,7 @@ def recsum(obj):
 return recsum(arr)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyintnulls(arr int8[]) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 res = 0
 for el in arr:
     if el is None:
@@ -83,7 +83,7 @@ for el in arr:
 return res
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyfloatarr(arr float8[]) RETURNS float8 AS $$
-# container: plc_python
+# container: plc_python_shared
 global num
 num = 0
 
@@ -101,7 +101,7 @@ def recsum(obj):
 return recsum(arr)/float(num)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytextarr(arr varchar[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 global res
 res = ''
 
@@ -118,139 +118,139 @@ recconcat(arr)
 return res
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytsarr(t timestamp[]) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return sum([1 if '2010' in x else 0 for x in t])
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybyteaarr(b bytea[]) RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return '|'.join([x.decode('UTF8') if x else 'None' for x in b])
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrint1(num int) RETURNS bool[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrint2(num int) RETURNS smallint[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrint4(num int) RETURNS int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrint8(num int) RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrfloat4(num int) RETURNS float4[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/2.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrfloat8(num int) RETURNS float8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/3.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrnumeric(num int) RETURNS numeric[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/4.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrtext(num int) RETURNS text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['number' + str(x) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrbytea(a bytea[]) RETURNS bytea[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return a
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrbytea2(num int) RETURNS bytea[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['bytea' + str(x) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrdate(num int) RETURNS date[] AS $$
-# container: plc_python
+# container: plc_python_shared
 import datetime
 dt = datetime.date(2016,12,31)
 dts = [dt + datetime.timedelta(days=x) for x in range(num)]
 return [x.strftime('%Y-%m-%d') for x in dts]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturntupint8() RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return (0,1,2,3,4,5)
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrint8nulls() RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [1,2,3,None,5,6,None,8,9]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrtextnulls() RETURNS text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['a','b',None,'d',None,'f']
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnarrmulti() RETURNS int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [[x for x in range(5)] for _ in range(5)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetofint8(num int) RETURNS setof int8 AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetofint4arr(num int) RETURNS setof int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [range(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetoftextarr(num int) RETURNS setof text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 def get_texts(n):
     return ['n'+str(x) for x in range(n)]
     
 return [get_texts(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetofdate(num int) RETURNS setof date AS $$
-# container: plc_python
+# container: plc_python_shared
 import datetime
 dt = datetime.date(2016,12,31)
 dts = [dt + datetime.timedelta(days=x) for x in range(num)]
 return [x.strftime('%Y-%m-%d') for x in dts]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetofint8yield(num int) RETURNS setof int8 AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 for x in range(num):
     yield x
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pywriteFile() RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 f = open("/tmp/foo", "w")
 f.write("foobar")
 f.close
 return 'wrote foobar to /tmp/foo'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyconcat(a text, b text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return a + b
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyconcatall() RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 res = plpy.execute('select fname from users order by 1')
 names = map(lambda x: x['fname'], res)
 return ','.join(names)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pynested_call_one(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 q = "SELECT pynested_call_two('%s')" % a
 r = plpy.execute(q)
 return r[0]
 $$ LANGUAGE plcontainer ;
 CREATE OR REPLACE FUNCTION pynested_call_two(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 q = "SELECT pynested_call_three('%s')" % a
 r = plpy.execute(q)
 return r[0]
 $$ LANGUAGE plcontainer ;
 CREATE OR REPLACE FUNCTION pynested_call_three(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return a
 $$ LANGUAGE plcontainer ;
 CREATE OR REPLACE FUNCTION py_plpy_get_record() RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 q = """SELECT 't'::bool as a,
               1::smallint as b,
@@ -289,7 +289,7 @@ else:
 return 11
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylogging() RETURNS void AS $$
-# container: plc_python
+# container: plc_python_shared
 plpy.debug('this is the debug message')
 plpy.log('this is the log message')
 plpy.info('this is the info message')
@@ -298,65 +298,65 @@ plpy.warning('this is the warning message')
 plpy.error('this is the error message')
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylogging2() RETURNS void AS $$
-# container: plc_python
+# container: plc_python_shared
 plpy.execute('select pylogging()')
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pygdset(key varchar, value varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 GD[key] = value
 return 'ok'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pygdgetall() RETURNS setof text AS $$
-# container: plc_python
+# container: plc_python_shared
 items = sorted(GD.items())
 return [ ':'.join([x[0],x[1]]) for x in items ]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pysdset(key varchar, value varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 SD[key] = value
 for k in sorted(SD.keys()):
     plpy.info("SD %s -> %s" % (k, SD[k]))
 return 'ok'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pysdgetall() RETURNS setof text AS $$
-# container: plc_python
+# container: plc_python_shared
 items = sorted(SD.items())
 return [ ':'.join([x[0],x[1]]) for x in items ]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyunargs1(varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return args[0]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyunargs2(a int, varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return str(a) + args[1]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyunargs3(a int, varchar, c varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return str(a) + args[1] + c
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyunargs4(int, int, int, int) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return len(args)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylargeint8in(a int8[]) RETURNS float8 AS $$
-#container : plc_python
+#container : plc_python_shared
 return sum(a)/float(len(a))
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylargeint8out(n int) RETURNS int8[] AS $$
-#container : plc_python
+#container : plc_python_shared
 return range(n)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylargetextin(t text) RETURNS int AS $$
-#container : plc_python
+#container : plc_python_shared
 return len(t)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pylargetextout(n int) RETURNS text AS $$
-#container : plc_python
+#container : plc_python_shared
 return ','.join([str(x) for x in range(1,n+1)])
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt1(r test_type) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 # Python 2
 if (sys.version_info.major == 2):
@@ -381,7 +381,7 @@ else:
 return 10
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt2(r test_type2) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 # Python 2
 if (sys.version_info.major == 2):
@@ -406,64 +406,64 @@ else:
 return 10
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt6() RETURNS test_type AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': True, 'b': 1, 'c': 2, 'd': 3, 'e': 4, 'f': 5, 'g': 6, 'h': 'foo'}
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt8() RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt11() RETURNS SETOF test_type4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt13(r test_type3) RETURNS test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt16() RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': [1,3], 'b': [2,4], 'c': ['foo','bar']}
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudtrecord1() RETURNS record AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': 2, 'c': 'foo'}
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudtrecord2() RETURNS SETOF record AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadint() RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return 'foo'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadfloat8() RETURNS float4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return 'foo'
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadudt() RETURNS test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': 2, 'd':'foo'}
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadudt2() RETURNS test_type4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': [1,'foo',3], 'c':['foo']}
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadarr() RETURNS int[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [1,2,3,'foo',5]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadarr2() RETURNS int[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return 1
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyinvalid_function() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.foobar(a, b)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyinvalid_syntax() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.foobar(a,1b)
 $$ LANGUAGE plcontainer;
@@ -473,7 +473,7 @@ import math
 return math.log10(100)
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyanaconda() RETURNS double precision AS $$
-# container: plc_anaconda
+# container: plc_python_shared
 import sklearn
 import numpy
 import scipy

--- a/tests/expected/plcontainer_function_python_gpdb5.out
+++ b/tests/expected/plcontainer_function_python_gpdb5.out
@@ -1,19 +1,19 @@
 CREATE OR REPLACE FUNCTION pytestudt3(r test_type3[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 res = ''
 for row in r:
     res += '#' + str(row['a']) + '|' + str(row['b']) + '|' + row['c']
 return res
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt4(r test_type4[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 res = ''
 for row in r:
     res += '#' + str(row['a']) + '|' + str(sum(row['b'])) + '|' + ','.join(row['c'])
 return res
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt5(r test_type4[]) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 if r is None:
     return 1
 for el in r:
@@ -22,37 +22,37 @@ for el in r:
 return 3
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt7() RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt9() RETURNS SETOF test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}],
          [{'a': 5, 'b': 6, 'c': 'buz'}, {'a': 7, 'b': 8, 'c': 'zzz'}] ]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt10() RETURNS test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt12() RETURNS SETOF test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}],
          [{'a': 5, 'b': [6,66], 'c': ['buz','buz2']}, {'a': 7, 'b': [8,88], 'c': ['zzz','zzz2']}] ]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt14(r test_type3[]) RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pytestudt15(r test_type3[]) RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadudtarr() RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ {'a': 1, 'b': 2, 'c': 'foo'}, {'a': 1, 'b': 2} ]
 $$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pybadudtarr2() RETURNS test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ {'a': 1, 'b': [2, 3], 'c': ['foo', 'bar']},
          {'a': 4, 'b': [5, 'f'], 'c': ['a', 'b']} ]
 $$ LANGUAGE plcontainer;

--- a/tests/sql/plcontainer_function_python.sql
+++ b/tests/sql/plcontainer_function_python.sql
@@ -1,82 +1,82 @@
 CREATE OR REPLACE FUNCTION pylog100() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.log10(100)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylog(a integer, b integer) RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.log(a, b)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybool(b bool) RETURNS bool AS $$
-# container: plc_python
+# container: plc_python_shared
 return b
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyint(i int2) RETURNS int2 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+1
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyint(i int4) RETURNS int4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+2
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyint(i int8) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 return i+3
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyfloat(f float4) RETURNS float4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return f+1
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyfloat(f float8) RETURNS float8 AS $$
-# container: plc_python
+# container: plc_python_shared
 return f+2
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pynumeric(n numeric) RETURNS numeric AS $$
-# container: plc_python
+# container: plc_python_shared
 return n+3.0
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytimestamp(t timestamp) RETURNS timestamp AS $$
-# container: plc_python
+# container: plc_python_shared
 return t
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytimestamptz(t timestamptz) RETURNS timestamptz AS $$
-# container: plc_python
+# container: plc_python_shared
 return t
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytext(t text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return t+'bar'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybytea(r bytea) RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybytea2() RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return None
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybytea3() RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return ''
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyintarr(arr int8[]) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 def recsum(obj):
     s = 0
     if type(obj) is list:
@@ -91,7 +91,7 @@ return recsum(arr)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyintnulls(arr int8[]) RETURNS int8 AS $$
-# container: plc_python
+# container: plc_python_shared
 res = 0
 for el in arr:
     if el is None:
@@ -100,7 +100,7 @@ return res
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyfloatarr(arr float8[]) RETURNS float8 AS $$
-# container: plc_python
+# container: plc_python_shared
 global num
 num = 0
 
@@ -119,7 +119,7 @@ return recsum(arr)/float(num)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytextarr(arr varchar[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 global res
 res = ''
 
@@ -137,67 +137,67 @@ return res
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytsarr(t timestamp[]) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return sum([1 if '2010' in x else 0 for x in t])
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybyteaarr(b bytea[]) RETURNS bytea AS $$
-# container: plc_python
+# container: plc_python_shared
 return '|'.join([x.decode('UTF8') if x else 'None' for x in b])
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrint1(num int) RETURNS bool[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrint2(num int) RETURNS smallint[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrint4(num int) RETURNS int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrint8(num int) RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrfloat4(num int) RETURNS float4[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/2.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrfloat8(num int) RETURNS float8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/3.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrnumeric(num int) RETURNS numeric[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x/4.0 for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrtext(num int) RETURNS text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['number' + str(x) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrbytea(a bytea[]) RETURNS bytea[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return a
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrbytea2(num int) RETURNS bytea[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['bytea' + str(x) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrdate(num int) RETURNS date[] AS $$
-# container: plc_python
+# container: plc_python_shared
 import datetime
 dt = datetime.date(2016,12,31)
 dts = [dt + datetime.timedelta(days=x) for x in range(num)]
@@ -205,37 +205,37 @@ return [x.strftime('%Y-%m-%d') for x in dts]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturntupint8() RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return (0,1,2,3,4,5)
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrint8nulls() RETURNS int8[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [1,2,3,None,5,6,None,8,9]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrtextnulls() RETURNS text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return ['a','b',None,'d',None,'f']
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnarrmulti() RETURNS int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [[x for x in range(5)] for _ in range(5)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnsetofint8(num int) RETURNS setof int8 AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [x for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnsetofint4arr(num int) RETURNS setof int[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 return [range(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnsetoftextarr(num int) RETURNS setof text[] AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 def get_texts(n):
     return ['n'+str(x) for x in range(n)]
     
@@ -243,7 +243,7 @@ return [get_texts(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnsetofdate(num int) RETURNS setof date AS $$
-# container: plc_python
+# container: plc_python_shared
 import datetime
 dt = datetime.date(2016,12,31)
 dts = [dt + datetime.timedelta(days=x) for x in range(num)]
@@ -251,13 +251,13 @@ return [x.strftime('%Y-%m-%d') for x in dts]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyreturnsetofint8yield(num int) RETURNS setof int8 AS $BODY$
-# container: plc_python
+# container: plc_python_shared
 for x in range(num):
     yield x
 $BODY$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pywriteFile() RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 f = open("/tmp/foo", "w")
 f.write("foobar")
 f.close
@@ -265,39 +265,39 @@ return 'wrote foobar to /tmp/foo'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyconcat(a text, b text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return a + b
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyconcatall() RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 res = plpy.execute('select fname from users order by 1')
 names = map(lambda x: x['fname'], res)
 return ','.join(names)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pynested_call_one(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 q = "SELECT pynested_call_two('%s')" % a
 r = plpy.execute(q)
 return r[0]
 $$ LANGUAGE plcontainer ;
 
 CREATE OR REPLACE FUNCTION pynested_call_two(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 q = "SELECT pynested_call_three('%s')" % a
 r = plpy.execute(q)
 return r[0]
 $$ LANGUAGE plcontainer ;
 
 CREATE OR REPLACE FUNCTION pynested_call_three(a text) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return a
 $$ LANGUAGE plcontainer ;
 
 CREATE OR REPLACE FUNCTION py_plpy_get_record() RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 q = """SELECT 't'::bool as a,
               1::smallint as b,
@@ -337,7 +337,7 @@ return 11
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylogging() RETURNS void AS $$
-# container: plc_python
+# container: plc_python_shared
 plpy.debug('this is the debug message')
 plpy.log('this is the log message')
 plpy.info('this is the info message')
@@ -347,24 +347,24 @@ plpy.error('this is the error message')
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylogging2() RETURNS void AS $$
-# container: plc_python
+# container: plc_python_shared
 plpy.execute('select pylogging()')
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pygdset(key varchar, value varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 GD[key] = value
 return 'ok'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pygdgetall() RETURNS setof text AS $$
-# container: plc_python
+# container: plc_python_shared
 items = sorted(GD.items())
 return [ ':'.join([x[0],x[1]]) for x in items ]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pysdset(key varchar, value varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 SD[key] = value
 for k in sorted(SD.keys()):
     plpy.info("SD %s -> %s" % (k, SD[k]))
@@ -372,53 +372,53 @@ return 'ok'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pysdgetall() RETURNS setof text AS $$
-# container: plc_python
+# container: plc_python_shared
 items = sorted(SD.items())
 return [ ':'.join([x[0],x[1]]) for x in items ]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyunargs1(varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return args[0]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyunargs2(a int, varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return str(a) + args[1]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyunargs3(a int, varchar, c varchar) RETURNS text AS $$
-# container: plc_python
+# container: plc_python_shared
 return str(a) + args[1] + c
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyunargs4(int, int, int, int) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return len(args)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylargeint8in(a int8[]) RETURNS float8 AS $$
-#container : plc_python
+#container : plc_python_shared
 return sum(a)/float(len(a))
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylargeint8out(n int) RETURNS int8[] AS $$
-#container : plc_python
+#container : plc_python_shared
 return range(n)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylargetextin(t text) RETURNS int AS $$
-#container : plc_python
+#container : plc_python_shared
 return len(t)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pylargetextout(n int) RETURNS text AS $$
-#container : plc_python
+#container : plc_python_shared
 return ','.join([str(x) for x in range(1,n+1)])
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt1(r test_type) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 # Python 2
 if (sys.version_info.major == 2):
@@ -445,7 +445,7 @@ $$ LANGUAGE plcontainer;
 
 
 CREATE OR REPLACE FUNCTION pytestudt2(r test_type2) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 import sys
 # Python 2
 if (sys.version_info.major == 2):
@@ -471,78 +471,78 @@ return 10
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt6() RETURNS test_type AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': True, 'b': 1, 'c': 2, 'd': 3, 'e': 4, 'f': 5, 'g': 6, 'h': 'foo'}
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt8() RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt11() RETURNS SETOF test_type4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt13(r test_type3) RETURNS test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt16() RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': [1,3], 'b': [2,4], 'c': ['foo','bar']}
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudtrecord1() RETURNS record AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': 2, 'c': 'foo'}
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudtrecord2() RETURNS SETOF record AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadint() RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 return 'foo'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadfloat8() RETURNS float4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return 'foo'
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadudt() RETURNS test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': 2, 'd':'foo'}
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadudt2() RETURNS test_type4 AS $$
-# container: plc_python
+# container: plc_python_shared
 return {'a': 1, 'b': [1,'foo',3], 'c':['foo']}
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadarr() RETURNS int[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [1,2,3,'foo',5]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadarr2() RETURNS int[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return 1
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyinvalid_function() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.foobar(a, b)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyinvalid_syntax() RETURNS double precision AS $$
-# container: plc_python
+# container: plc_python_shared
 import math
 return math.foobar(a,1b)
 $$ LANGUAGE plcontainer;
@@ -554,7 +554,7 @@ return math.log10(100)
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pyanaconda() RETURNS double precision AS $$
-# container: plc_anaconda
+# container: plc_python_shared
 import sklearn
 import numpy
 import scipy

--- a/tests/sql/plcontainer_function_python_gpdb5.sql
+++ b/tests/sql/plcontainer_function_python_gpdb5.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION pytestudt3(r test_type3[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 res = ''
 for row in r:
     res += '#' + str(row['a']) + '|' + str(row['b']) + '|' + row['c']
@@ -7,7 +7,7 @@ return res
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt4(r test_type4[]) RETURNS varchar AS $$
-# container: plc_python
+# container: plc_python_shared
 res = ''
 for row in r:
     res += '#' + str(row['a']) + '|' + str(sum(row['b'])) + '|' + ','.join(row['c'])
@@ -15,7 +15,7 @@ return res
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt5(r test_type4[]) RETURNS int AS $$
-# container: plc_python
+# container: plc_python_shared
 if r is None:
     return 1
 for el in r:
@@ -25,44 +25,44 @@ return 3
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt7() RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt9() RETURNS SETOF test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ [{'a': 1, 'b': 2, 'c': 'foo'}, {'a': 3, 'b': 4, 'c': 'bar'}],
          [{'a': 5, 'b': 6, 'c': 'buz'}, {'a': 7, 'b': 8, 'c': 'zzz'}] ]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt10() RETURNS test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt12() RETURNS SETOF test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ [{'a': 1, 'b': [2,22], 'c': ['foo','foo2']}, {'a': 3, 'b': [4,44], 'c': ['bar','bar2']}],
          [{'a': 5, 'b': [6,66], 'c': ['buz','buz2']}, {'a': 7, 'b': [8,88], 'c': ['zzz','zzz2']}] ]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt14(r test_type3[]) RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pytestudt15(r test_type3[]) RETURNS SETOF test_type3 AS $$
-# container: plc_python
+# container: plc_python_shared
 return r
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadudtarr() RETURNS test_type3[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ {'a': 1, 'b': 2, 'c': 'foo'}, {'a': 1, 'b': 2} ]
 $$ LANGUAGE plcontainer;
 
 CREATE OR REPLACE FUNCTION pybadudtarr2() RETURNS test_type4[] AS $$
-# container: plc_python
+# container: plc_python_shared
 return [ {'a': 1, 'b': [2, 3], 'c': ['foo', 'bar']},
          {'a': 4, 'b': [5, 'f'], 'c': ['a', 'b']} ]
 $$ LANGUAGE plcontainer;


### PR DESCRIPTION
There are some issues of plcontainer function test
1 On centos7, Perl need to install cpan to support dumper which is needed by pg_regeress
2 On centos6, Docker version is too old, and there are no outputs for docker load command. So we add an option to specify the image name explicitly
3 Function test has false positive problem. We add "set -eox" in ssh command to fix it. 