### PR TITLE
remove useless refresh since every sql file test in pg_regress will open new session

### DIFF
--- a/tests/expected/plcontainer_function_python_network.out
+++ b/tests/expected/plcontainer_function_python_network.out
@@ -46,10 +46,3 @@ select python_network_test2() from test_python_network;
 (11 rows)
 
 \! plcontainer configure --restore -y
-select * from plcontainer_refresh_config;
- gp_segment_id | plcontainer_refresh_local_config 
----------------+----------------------------------
-             0 | ok
-            -1 | ok
-(2 rows)
-

--- a/tests/sql/plcontainer_function_python_network.sql
+++ b/tests/sql/plcontainer_function_python_network.sql
@@ -19,5 +19,3 @@ select python_network_test1(i) from test_python_network;
 select python_network_test2() from test_python_network;
 
 \! plcontainer configure --restore -y
-
-select * from plcontainer_refresh_config;


### PR DESCRIPTION
Also, this will cause regression tests failed in a different cluster.