### PR TITLE
Delete containers when connection to container fails.

### DIFF
--- a/src/common/comm_connectivity.c
+++ b/src/common/comm_connectivity.c
@@ -39,7 +39,7 @@ static ssize_t plcSocketRecv(plcConn *conn, void *ptr, size_t len) {
     while (sz <= 0) {
         sz = recv(conn->sock, ptr, len, 0);
 
-        /* If receive command is terminated by SIGINT */
+        /* If receive command is terminated by SIGINT/SIGTERM, etc. */
         if (sz < 0 && errno == EINTR) {
             lprintf(ERROR, "Query and PL/Container connections are terminated "
 					"by user request: %s", strerror(errno));
@@ -75,7 +75,7 @@ static ssize_t plcSocketSend(plcConn *conn, const void *ptr, size_t len) {
  *
  * Returns 0 on success, -1 on failure
  */
-static int plcBufferMaybeFlush (plcConn *conn, bool isForse) {
+static int plcBufferMaybeFlush(plcConn *conn, bool isForse) {
     int res = 0;
     plcBuffer *buf = conn->buffer[PLC_OUTPUT_BUFFER];
 

--- a/src/containers.c
+++ b/src/containers.c
@@ -250,7 +250,7 @@ static char *get_uds_fn(int container_slot) {
 }
 
 plcConn *start_container(plcContainerConf *conf) {
-    int port;
+    int port = 0;
     unsigned int sleepus = 25000;
     unsigned int sleepms = 0;
     plcMsgPing *mping = NULL;
@@ -363,7 +363,7 @@ plcConn *start_container(plcContainerConf *conf) {
     return conn;
 }
 
-void stop_containers() {
+void delete_containers() {
     int i;
 
     if (containers_init != 0) {
@@ -378,7 +378,7 @@ void stop_containers() {
 
                     sockfd = plc_backend_connect();
                     if (sockfd > 0) {
-                        plc_backend_kill(sockfd, containers[i].dockerid);
+                        plc_backend_delete(sockfd, containers[i].dockerid);
                         plc_backend_disconnect(sockfd);
                     }
                     pfree(containers[i].dockerid);

--- a/src/containers.h
+++ b/src/containers.h
@@ -30,7 +30,7 @@ plcConn *find_container(const char *image);
 /* start a new docker container using the given image  */
 plcConn *start_container(plcContainerConf *conf);
 
-/* Function terminates all the container connections */
-void stop_containers(void);
+/* Function deletes all the containers */
+void delete_containers(void);
 
 #endif /* PLC_CONTAINERS_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,14 +9,22 @@ include $(PGXS)
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB) --init-file=./init_file
 
-REGRESS_BASIC = plcontainer_install plcontainer_schema
+REGRESS_BASIC = plcontainer_install \
+	plcontainer_schema
+
 # R Regression Tests
-REGRESS_R = plcontainer_function_r plcontainer_function_r_gpdb5
-REGRESS_R_TESTS = plcontainer_test_r plcontainer_test_r_gpdb5
+REGRESS_R = plcontainer_function_r \
+	plcontainer_function_r_gpdb5
+REGRESS_R_TESTS = plcontainer_test_r \
+	plcontainer_test_r_gpdb5
 
 # Python Regression Tests
-REGRESS_PYTHON = plcontainer_function_python plcontainer_function_python_gpdb5
-REGRESS_PYTHON_TESTS = plcontainer_test_python plcontainer_test_python_gpdb5 plcontainer_function_python_network
+REGRESS_PYTHON = plcontainer_function_python \
+	plcontainer_function_python_gpdb5
+REGRESS_PYTHON_TESTS = plcontainer_test_python \
+	plcontainer_test_python_gpdb5 \
+	plcontainer_exception_python \
+	plcontainer_function_python_network
 
 # Regression Tests for GPDB5
 REGRESS_GPDB5 = $(REGRESS_BASIC) $(REGRESS_R) $(REGRESS_PYTHON) $(REGRESS_PYTHON_TESTS)

--- a/tests/expected/plcontainer_exception_python.out
+++ b/tests/expected/plcontainer_exception_python.out
@@ -77,3 +77,18 @@ NOTICE:  Success:
  t
 (1 row)
 
+-- Test container kill-9-ed.
+select pyzero();
+ pyzero 
+--------
+      0
+(1 row)
+
+select pykillself();
+ERROR:  Error receiving data from the client: -3. Maybe retry later. (plcontainer.c:206)
+select pyzero();
+ pyzero 
+--------
+      0
+(1 row)
+

--- a/tests/expected/plcontainer_function_python.out
+++ b/tests/expected/plcontainer_function_python.out
@@ -200,7 +200,7 @@ CREATE OR REPLACE FUNCTION pyreturnsetoftextarr(num int) RETURNS setof text[] AS
 # container: plc_python_shared
 def get_texts(n):
     return ['n'+str(x) for x in range(n)]
-    
+ 
 return [get_texts(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 CREATE OR REPLACE FUNCTION pyreturnsetofdate(num int) RETURNS setof date AS $$
@@ -484,4 +484,15 @@ CREATE OR REPLACE FUNCTION pyversion() RETURNS varchar AS $$
 # container : plc_python_shared
 import sys
 return str(sys.version_info)
+$$ LANGUAGE plcontainer;
+CREATE OR REPLACE FUNCTION pykillself() RETURNS integer AS $$
+# container: plc_python_shared
+import os
+import signal
+pid=os.getpid()
+os.kill(pid, signal.SIGKILL)
+$$ LANGUAGE plcontainer;
+CREATE OR REPLACE FUNCTION pyzero() RETURNS integer AS $$
+# container: plc_python_shared
+return 0
 $$ LANGUAGE plcontainer;

--- a/tests/init_file
+++ b/tests/init_file
@@ -11,4 +11,6 @@ m/^[0-9]{8}:[0-9]{2}:[0-9]{2}:[0-9]{2}.*/
 -- start_matchsubs
 m/ls: cannot access '.*'.*/
 s/ls: cannot access '(.*)'(.*)/ls: cannot access $1$2/
+m/plcontainer.c:\d+\)/
+s/plcontainer.c:\d+\)/plcontainer.c:xxx/
 -- end_matchsubs

--- a/tests/sql/plcontainer_exception_python.sql
+++ b/tests/sql/plcontainer_exception_python.sql
@@ -37,3 +37,8 @@ SELECT pg_sleep(5);
 -- reset the injection points
 SELECT gp_inject_fault('plcontainer_before_container_started', 'reset', 2);
 SELECT gp_inject_fault('plcontainer_before_container_connected', 'reset', 2);
+
+-- Test container kill-9-ed.
+select pyzero();
+select pykillself();
+select pyzero();

--- a/tests/sql/plcontainer_function_python.sql
+++ b/tests/sql/plcontainer_function_python.sql
@@ -238,7 +238,7 @@ CREATE OR REPLACE FUNCTION pyreturnsetoftextarr(num int) RETURNS setof text[] AS
 # container: plc_python_shared
 def get_texts(n):
     return ['n'+str(x) for x in range(n)]
-    
+ 
 return [get_texts(x+1) for x in range(num)]
 $BODY$ LANGUAGE plcontainer;
 
@@ -566,4 +566,17 @@ CREATE OR REPLACE FUNCTION pyversion() RETURNS varchar AS $$
 # container : plc_python_shared
 import sys
 return str(sys.version_info)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION pykillself() RETURNS integer AS $$
+# container: plc_python_shared
+import os
+import signal
+pid=os.getpid()
+os.kill(pid, signal.SIGKILL)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION pyzero() RETURNS integer AS $$
+# container: plc_python_shared
+return 0
 $$ LANGUAGE plcontainer;


### PR DESCRIPTION
Else if client exits abnormally sql queries could continuously fail until QE terminates.

We do not apply the more friendly solution (e.g. seamlessly relaunch containers)
since it will introduce some complexity and this case is rare.
Instead we just tell users that query fails and then they could retry.

In this patch we also modify to not just kill containers, but
further delete containers.