### PR TITLE
support docker 1.7.1 (API v1.19) in Centos 6

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -12,7 +12,6 @@
 #include <unistd.h>
 #include <time.h>
 #include <libgen.h>
-#include <signal.h>
 #include <sys/wait.h>
 
 #include "postgres.h"
@@ -83,7 +82,8 @@ static int container_is_alive(char *dockerid) {
         if (res < 0) {
             return_code = res;
         }
-        if (element != NULL && strcmp("exited", element) == 0){
+        if (element != NULL && (strcmp("exited", element) == 0 ||
+			strcmp("false", element) == 0 )){
             return_code = plc_backend_delete(sockfd, dockerid);
         }
         plc_backend_disconnect(sockfd);

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -361,8 +361,11 @@ static int recv_string_mapping(int sockfd, char **element, plcInspectionMode typ
             regex =
                     "\"8080\\/tcp\"\\s*\\:\\s*\\[.*\"HostPort\"\\s*\\:\\s*\"([0-9]*)\".*\\]";
         } else if (type == PLC_INSPECT_STATUS) {
-            regex =
-                    "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+			if (strcmp(plc_docker_api_version, "v1.19") == 0){
+				regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
+			}else{
+				regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+			}
         }
 
 

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -26,7 +26,7 @@
 #ifdef DOCKER_API_LOW
     static char *plc_docker_api_version = "v1.19";
 #else
-    static char *plc_docker_api_version = "v1.21";
+    static char *plc_docker_api_version = "v1.27";
 #endif
 
 // Default location of the Docker API unix socket
@@ -361,11 +361,11 @@ static int recv_string_mapping(int sockfd, char **element, plcInspectionMode typ
             regex =
                     "\"8080\\/tcp\"\\s*\\:\\s*\\[.*\"HostPort\"\\s*\\:\\s*\"([0-9]*)\".*\\]";
         } else if (type == PLC_INSPECT_STATUS) {
-			if (strcmp(plc_docker_api_version, "v1.19") == 0){
-				regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
-			}else{
-				regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
-			}
+#ifdef DOCKER_API_LOW
+			regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
+#else
+			regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+#endif
         }
 
 

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -26,7 +26,7 @@ static char *plc_docker_socket = "/var/run/docker.sock";
 #ifdef DOCKER_API_LOW
     static char *plc_docker_url_prefix = "http:/v1.19";
 #else
-    static char *plc_docker_url_prefix = "http:/v1.21";
+    static char *plc_docker_url_prefix = "http:/v1.27";
 #endif
 /* Static functions of the Docker API module */
 static plcCurlBuffer *plcCurlBufferInit();

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -407,8 +407,11 @@ int plc_docker_inspect_container(pg_attribute_unused() int sockfd, char *name, c
             regex =
                     "\"8080\\/tcp\"\\s*\\:\\s*\\[.*\"HostPort\"\\s*\\:\\s*\"([0-9]*)\".*\\]";
         } else if (type == PLC_INSPECT_STATUS) {
-            regex =
-                    "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+#ifdef DOCKER_API_LOW
+			regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
+#else
+			regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+#endif
         }
 
         res = docker_parse_string_mapping(response->data, element, regex);


### PR DESCRIPTION
Add Centos 6 docker API support as its API version is too low and has been changed in newer version of docker.