### PR TITLE
Show diff output on concourse if testing fails.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,7 +42,7 @@ all: tests
 .PHONY: tests
 tests:
 	$(top_builddir)/src/test/regress/pg_regress \
-				--psqldir=$(PSQLDIR) $(REGRESS_OPTS) $(REGRESS_GPDB5)
+				--psqldir=$(PSQLDIR) $(REGRESS_OPTS) $(REGRESS_GPDB5) || if [[ -f regression.diffs ]]; then cat regression.diffs; exit 1; fi
 
 .PHONY: submake
 submake:


### PR DESCRIPTION
This saves some time when there is test failure since usually users need to fly to concourse instance to check.