### PR TITLE
Fix random failure of fault injection test case.

### DIFF
--- a/tests/expected/plcontainer_exception_python.out
+++ b/tests/expected/plcontainer_exception_python.out
@@ -1,8 +1,6 @@
 --  Test <defunct> processes are reaped after a new backend is created.
 select pykillself();
 ERROR:  Error receiving data from the client: -3. Maybe retry later. (plcontainer.c:206)
-select pykillself();
-ERROR:  Error receiving data from the client: -3. Maybe retry later. (plcontainer.c:206)
 SELECT pg_sleep(5);
  pg_sleep 
 ----------

--- a/tests/expected/plcontainer_faultinject_python.out
+++ b/tests/expected/plcontainer_faultinject_python.out
@@ -28,7 +28,7 @@ SELECT pg_sleep(5);
 -- end_ignore
 \! docker ps -a | wc -l
 1
-\! ps -ef | grep plcontainer | grep -v pg_regress | wc -l
+\! ps -ef | grep "plcontainer cleaner" | grep -v pg_regress | wc -l
 1
 -- start_ignore
 -- Start a container
@@ -60,7 +60,7 @@ SELECT pg_sleep(5);
 -- end_ignore
 \! docker ps -a | wc -l
 1
-\! ps -ef | grep plcontainer | grep -v pg_regress | wc -l
+\! ps -ef | grep "plcontainer cleaner" | grep -v pg_regress | wc -l
 1
 -- reset the injection points
 SELECT gp_inject_fault('plcontainer_before_container_started', 'reset', 2);

--- a/tests/sql/plcontainer_exception_python.sql
+++ b/tests/sql/plcontainer_exception_python.sql
@@ -1,6 +1,5 @@
 --  Test <defunct> processes are reaped after a new backend is created.
 select pykillself();
-select pykillself();
 SELECT pg_sleep(5);
 -- Wait for 5 seconds so that cleanup processes exit.
 \!ps -ef |grep [p]ostgres|grep defunct |wc -l

--- a/tests/sql/plcontainer_faultinject_python.sql
+++ b/tests/sql/plcontainer_faultinject_python.sql
@@ -19,7 +19,7 @@ SELECT pg_sleep(5);
 -- end_ignore
 
 \! docker ps -a | wc -l
-\! ps -ef | grep plcontainer | grep -v pg_regress | wc -l
+\! ps -ef | grep "plcontainer cleaner" | grep -v pg_regress | wc -l
 
 -- start_ignore
 -- Start a container
@@ -32,7 +32,7 @@ SELECT pg_sleep(5);
 -- end_ignore
 
 \! docker ps -a | wc -l
-\! ps -ef | grep plcontainer | grep -v pg_regress | wc -l
+\! ps -ef | grep "plcontainer cleaner" | grep -v pg_regress | wc -l
 
 -- reset the injection points
 SELECT gp_inject_fault('plcontainer_before_container_started', 'reset', 2);


### PR DESCRIPTION
We need to specify the exact name of "plcontainer cleaner" processes because in pipeline we introduce an additional process with name containing "plcontainer" when run test by bash "bash plcontainer.sh"
Signed-off-by: Haozhou Wang <hawang@pivotal.io>