### PR TITLE
Refactor docker regex code to remove the duplicate code

### DIFF
--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -23,6 +23,7 @@ typedef enum {
 typedef enum {
 	PLC_INSPECT_STATUS = 0,
 	PLC_INSPECT_PORT = 1,
+	PLC_INSPECT_NAME = 2,
 	PLC_INSPECT_PORT_UNKNOWN,
 } plcInspectionMode;
 

--- a/src/plc_docker_common.c
+++ b/src/plc_docker_common.c
@@ -8,13 +8,11 @@
 #include "plc_docker_common.h"
 #include "regex/regex.h"
 
-int docker_parse_string_mapping(char *response, char **element, char *plc_docker_regex) {
+static int docker_parse_string_mapping(char *response, regmatch_t pmatch[], int size, char *plc_docker_regex) {
     // Regular expression for parsing container inspection JSON response
 
     regex_t     preg;
-    regmatch_t  pmatch[2];
     int         res = 0;
-    int         len = 0;
     int         wmasklen, masklen;
     pg_wchar   *mask;
     int         wdatalen, datalen;
@@ -40,7 +38,7 @@ int docker_parse_string_mapping(char *response, char **element, char *plc_docker
                      wdatalen,
                      0,
                      NULL,
-                     2,
+                     size,
                      pmatch,
                      0);
     pfree(data);
@@ -50,100 +48,48 @@ int docker_parse_string_mapping(char *response, char **element, char *plc_docker
     }
 
     if (pmatch[1].rm_so == -1) {
-        elog(LOG, "Could not find regex match '%s' for '%s'", plc_docker_regex, response);
-        return -1;
+           elog(LOG, "Could not find regex match '%s' for '%s'", plc_docker_regex, response);
+           return -1;
     }
 
-    len = pmatch[1].rm_eo - pmatch[1].rm_so;
-    *element = palloc(len + 1);
-    memcpy(*element, response + pmatch[1].rm_so, len);
-    (*element)[len] = '\0';
-
+    pg_regfree(&preg);
     return 0;
 }
 
 int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
     char *regex = NULL;
 	int res = 0;
+    regmatch_t  pmatch[2];
+    int         len = 0;
 
-	if (type == PLC_INSPECT_PORT) {
-		regex =
-				"\"8080\\/tcp\"\\s*\\:\\s*\\[.*\"HostPort\"\\s*\\:\\s*\"([0-9]*)\".*\\]";
-	} else if (type == PLC_INSPECT_STATUS) {
+    switch (type) {
+        case PLC_INSPECT_PORT:
+            regex =
+            	"\"8080\\/tcp\"\\s*\\:\\s*\\[.*\"HostPort\"\\s*\\:\\s*\"([0-9]*)\".*\\]";
+            break;
+        case PLC_INSPECT_STATUS:
 #ifdef DOCKER_API_LOW
-		regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
+		    regex = "\\s*\"Running\\s*\"\\:\\s*(\\w+)\\s*";
 #else
-		regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
+		    regex = "\\s*\"Status\\s*\"\\:\\s*\"(\\w+)\"\\s*";
 #endif
-	}
+            break;
+        case PLC_INSPECT_NAME:
+            regex =
+                "\\{\\s*\"[Ii][Dd]\\s*\"\\:\\s*\"(\\w+)\"\\s*,\\s*\"[Ww]arnings\"\\s*\\:([^\\}]*)\\s*\\}";
+            break;
+        default:
+            elog(LOG, "Error PLC inspection mode");
+            return -1;
+    }
 
-	res = docker_parse_string_mapping(buf, element, regex);
+	res = docker_parse_string_mapping(buf, pmatch, 2, regex);
+
+    len = pmatch[1].rm_eo - pmatch[1].rm_so;
+    *element = palloc(len + 1);
+    memcpy(*element, buf + pmatch[1].rm_so, len);
+    (*element)[len] = '\0';
 
     return res;
 }
 
-/* Parse container ID out of JSON response */
-int docker_parse_container_id(char* response, char **name) {
-    // Regular expression for parsing "create" call JSON response
-    char *plc_docker_containerid_regex =
-            "\\{\\s*\"[Ii][Dd]\\s*\"\\:\\s*\"(\\w+)\"\\s*,\\s*\"[Ww]arnings\"\\s*\\:([^\\}]*)\\s*\\}";
-    regex_t     preg;
-    regmatch_t  pmatch[3];
-    int         res = 0;
-    int         len = 0;
-    int         wmasklen, masklen;
-    pg_wchar   *mask;
-    int         wdatalen, datalen;
-    pg_wchar   *data;
-
-    masklen = strlen(plc_docker_containerid_regex);
-    mask = (pg_wchar *) palloc((masklen + 1) * sizeof(pg_wchar));
-    wmasklen = pg_mb2wchar_with_len(plc_docker_containerid_regex, mask, masklen);
-
-    res = pg_regcomp(&preg, mask, wmasklen, REG_ADVANCED);
-    pfree(mask);
-    if (res < 0) {
-        elog(LOG, "Cannot compile Postgres regular expression: '%s'", strerror(errno));
-        return -1;
-    }
-
-    datalen = strlen(response);
-    data = (pg_wchar *) palloc((datalen + 1) * sizeof(pg_wchar));
-    wdatalen = pg_mb2wchar_with_len(response, data, datalen);
-
-    res = pg_regexec(&preg,
-                     data,
-                     wdatalen,
-                     0,
-                     NULL,
-                     3,
-                     pmatch,
-                     0);
-    pfree(data);
-    if (res == REG_NOMATCH) {
-        elog(LOG, "Docker API response does not match regular expression: '%s'", response);
-        return -1;
-    }
-
-    if (pmatch[1].rm_so == -1) {
-        elog(LOG, "Postgres regex failed to extract created container name from Docker API response: '%s'", response);
-        return -1;
-    }
-
-    len = pmatch[1].rm_eo - pmatch[1].rm_so;
-    *name = palloc(len + 1);
-    memcpy(*name, response + pmatch[1].rm_so, len);
-    (*name)[len] = '\0';
-
-    if (pmatch[2].rm_so != -1 && pmatch[2].rm_eo - pmatch[2].rm_so > 10) {
-        char *err = NULL;
-        len = pmatch[2].rm_eo - pmatch[2].rm_so;
-        err = palloc(len+1);
-        memcpy(err, response + pmatch[2].rm_so, len);
-        err[len] = '\0';
-        elog(LOG, "Docker API 'create' call returned warning message: '%s'", err);
-    }
-
-    pg_regfree(&preg);
-    return 0;
-}

--- a/src/plc_docker_common.c
+++ b/src/plc_docker_common.c
@@ -79,7 +79,7 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
                 "\\{\\s*\"[Ii][Dd]\\s*\"\\:\\s*\"(\\w+)\"\\s*,\\s*\"[Ww]arnings\"\\s*\\:([^\\}]*)\\s*\\}";
             break;
         default:
-            elog(LOG, "Error PLC inspection mode");
+            elog(LOG, "Error PLC inspection mode, unacceptable inpsection type %d", type);
             return -1;
     }
 

--- a/src/plc_docker_common.h
+++ b/src/plc_docker_common.h
@@ -12,7 +12,6 @@
 
 #include "plc_backend_api.h"
 
-int docker_parse_string_mapping(char *response, char **element, char *plc_docker_regex);
 int docker_parse_container_id(char* response, char **name);
 int docker_inspect_string(char *buf, char **element, plcInspectionMode type);
 

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -217,8 +217,8 @@ int plc_docker_create_container(plcContainerConf *conf, char **name, int contain
 	if (res < 0) {
 		goto cleanup;
 	}
+    res = docker_inspect_string(response->data, name, PLC_INSPECT_NAME);
 
-	res = docker_parse_container_id(response->data, name);
 	if (res < 0) {
 		snprintf(api_error_message, sizeof(api_error_message),
 				 "Error parsing container ID during creating container");


### PR DESCRIPTION
1. Combine get container id and inspection regex funtion into one
2. Remove conatiner id warnning regex, it is already logged into
   GPDB in previous log