### PR TITLE
fix image tarball file not found

### DIFF
--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -12,8 +12,8 @@ source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 gppkg -i /tmp/plcontainer_gpdb_build/plcontainer-concourse-centos*.gppkg; \
 \""
 
-scp -r plcontainer_pyclient_docker_image/plcontainer-devel-images.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
-scp -r plcontainer_rclient_docker_image/plcontainer-devel-images.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
+scp -r plcontainer_pyclient_docker_image/plcontainer-*.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
+scp -r plcontainer_rclient_docker_image/plcontainer-*.tar.gz mdw:/usr/local/greenplum-db-devel/share/postgresql/plcontainer/
 
 ssh mdw "bash -c \" \
 set -eox pipefail; \


### PR DESCRIPTION
the image tarball names are changed, so command scp cannot find the image tar.gz file. Use * instead.