### PR TITLE
Add index in the prefix of domain socket path.

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -36,7 +36,6 @@ typedef struct {
 #define CONTAINER_NUMBER 10
 #define CONATINER_WAIT_TIMEOUT 2
 #define CONATINER_CONNECT_TIMEOUT 120
-#define MAX_DOCKER_ID_LENGTH 64
 
 static int containers_init = 0;
 static container_t *containers;
@@ -222,7 +221,7 @@ static char *get_uds_fn(char* uds_dir) {
 	char *uds_fn = NULL;
 	int   sz;
 
-	/* filename: IPC_GPDB_BASE_DIR + "." + DockerID + "." + container_slot / UDS_SHARED_FILE */
+	/* filename: IPC_GPDB_BASE_DIR + "." + PID + "." + DOMAIN_SOCKET_NO  + "." + container_slot / UDS_SHARED_FILE */
 	sz = strlen(uds_dir) + 1 + MAX_SHARED_FILE_SZ + 1;
 	uds_fn = pmalloc(sz);
 	snprintf(uds_fn, sz, "%s/%s", uds_dir, UDS_SHARED_FILE);

--- a/src/containers.c
+++ b/src/containers.c
@@ -247,7 +247,12 @@ plcConn *start_backend(plcContainerConf *conf) {
     enum PLC_BACKEND_TYPE plc_backend_type = BACKEND_DOCKER;
     plc_backend_prepareImplementation(plc_backend_type);
 
-    res = plc_backend_create(conf, &dockerid, &uds_dir, container_slot);
+    /*
+     *  Here the uds_dir is only used by connection of domain socket type
+     *  It remains NULL for connection of non domain socket type.
+     *
+     */
+    res = plc_backend_create(conf, &dockerid, container_slot, &uds_dir);
     if (res < 0) {
         elog(ERROR, "%s", api_error_message);
         return conn;

--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -36,8 +36,8 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
     }
 }
 
-int plc_backend_create(plcContainerConf *conf, char **name, int container_slot){
-    return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, container_slot) : 0;
+int plc_backend_create(plcContainerConf *conf, char **name, char **uds_dir, int container_slot){
+    return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, uds_dir, container_slot) : 0;
 }
 
 int plc_backend_start(char *name){

--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -36,8 +36,8 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
     }
 }
 
-int plc_backend_create(plcContainerConf *conf, char **name, char **uds_dir, int container_slot){
-    return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, uds_dir, container_slot) : 0;
+int plc_backend_create(plcContainerConf *conf, char **name, int container_slot, char **uds_dir){
+    return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, container_slot, uds_dir) : 0;
 }
 
 int plc_backend_start(char *name){

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -15,7 +15,7 @@
 
 extern char api_error_message[256];
 
-typedef int ( * PLC_FPTR_create)     (plcContainerConf *conf, char **name, int container_slot);
+typedef int ( * PLC_FPTR_create)     (plcContainerConf *conf, char **name, char **uds_dir, int container_slot);
 typedef int ( * PLC_FPTR_start)      (char *name);
 typedef int ( * PLC_FPTR_kill)       (char *name);
 typedef int ( * PLC_FPTR_inspect)    (char *name, char **element, plcInspectionMode type);
@@ -44,7 +44,7 @@ enum PLC_BACKEND_TYPE {
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
 /* interface for plc backend*/
-int plc_backend_create(plcContainerConf *conf, char **name, int container_slot);
+int plc_backend_create(plcContainerConf *conf, char **name, char ** uds_dir, int container_slot);
 int plc_backend_start(char *name);
 int plc_backend_kill(char *name);
 int plc_backend_inspect(char *name, char **element, plcInspectionMode type);

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -15,7 +15,7 @@
 
 extern char api_error_message[256];
 
-typedef int ( * PLC_FPTR_create)     (plcContainerConf *conf, char **name, char **uds_dir, int container_slot);
+typedef int ( * PLC_FPTR_create)     (plcContainerConf *conf, char **name, int container_slot, char **uds_dir);
 typedef int ( * PLC_FPTR_start)      (char *name);
 typedef int ( * PLC_FPTR_kill)       (char *name);
 typedef int ( * PLC_FPTR_inspect)    (char *name, char **element, plcInspectionMode type);
@@ -44,7 +44,7 @@ enum PLC_BACKEND_TYPE {
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
 /* interface for plc backend*/
-int plc_backend_create(plcContainerConf *conf, char **name, char ** uds_dir, int container_slot);
+int plc_backend_create(plcContainerConf *conf, char **name, int container_slot, char ** uds_dir);
 int plc_backend_start(char *name);
 int plc_backend_kill(char *name);
 int plc_backend_inspect(char *name, char **element, plcInspectionMode type);

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -23,7 +23,7 @@
 
 static plcContainerConf *plcContConf = NULL;
 static int plcNumContainers = 0;
-static int domain_socket_no = 0;
+static int64_t domain_socket_no = 0;
 
 static int parse_container(xmlNode *node, plcContainerConf *conf);
 static plcContainerConf *get_containers(xmlNode *node, int *size);
@@ -409,7 +409,7 @@ char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_
 			/* Directory for QE : IPC_GPDB_BASE_DIR + "." + PID + "." + container_slot */
 			int gpdb_dir_sz;
 
-			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 4 + 1 + 4 + 1;
+			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 16 + 1 + 4 + 1;
 			*uds_dir = pmalloc(gpdb_dir_sz);
 			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
 			volumes[i] = pmalloc(10 + gpdb_dir_sz + strlen(IPC_CLIENT_DIR));

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -23,7 +23,7 @@
 
 static plcContainerConf *plcContConf = NULL;
 static int plcNumContainers = 0;
-static int domain_socket_num = 0;
+static int domain_socket_no = 0;
 
 static int parse_container(xmlNode *node, plcContainerConf *conf);
 static plcContainerConf *get_containers(xmlNode *node, int *size);
@@ -411,7 +411,7 @@ char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_
 
 			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 4 + 1 + 4 + 1;
 			*uds_dir = pmalloc(gpdb_dir_sz);
-			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_num++, container_slot);
+			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
 			volumes[i] = pmalloc(10 + gpdb_dir_sz + strlen(IPC_CLIENT_DIR));
 			sprintf(volumes[i], " %c\"%s:%s:rw\"", comma, *uds_dir, IPC_CLIENT_DIR);
             totallen += strlen(volumes[i]);

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -23,7 +23,9 @@
 
 static plcContainerConf *plcContConf = NULL;
 static int plcNumContainers = 0;
-static int64_t domain_socket_no = 0;
+// we just want to avoid cleanup process to remove previous domain
+// socket file, so int32 is sufficient
+static int domain_socket_no = 0;
 
 static int parse_container(xmlNode *node, plcContainerConf *conf);
 static plcContainerConf *get_containers(xmlNode *node, int *size);
@@ -369,7 +371,7 @@ plcContainerConf *plc_get_container_config(char *name) {
     return result;
 }
 
-char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_slot, bool *has_error) {
+char *get_sharing_options(plcContainerConf *conf, int container_slot, bool *has_error, char **uds_dir) {
     char *res = NULL;
 
 	*has_error = false;
@@ -409,9 +411,9 @@ char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_
 			/* Directory for QE : IPC_GPDB_BASE_DIR + "." + PID + "." + container_slot */
 			int gpdb_dir_sz;
 
-			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 4 + 1 + 16 + 1 + 4 + 1;
+			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 16 + 1 + 4 + 1;
 			*uds_dir = pmalloc(gpdb_dir_sz);
-			sprintf(*uds_dir, "%s.%d.%ld.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
+			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
 			volumes[i] = pmalloc(10 + gpdb_dir_sz + strlen(IPC_CLIENT_DIR));
 			sprintf(volumes[i], " %c\"%s:%s:rw\"", comma, *uds_dir, IPC_CLIENT_DIR);
             totallen += strlen(volumes[i]);

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -409,9 +409,9 @@ char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_
 			/* Directory for QE : IPC_GPDB_BASE_DIR + "." + PID + "." + container_slot */
 			int gpdb_dir_sz;
 
-			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 16 + 1 + 4 + 1;
+			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 4 + 1 + 16 + 1 + 4 + 1;
 			*uds_dir = pmalloc(gpdb_dir_sz);
-			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
+			sprintf(*uds_dir, "%s.%d.%ld.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
 			volumes[i] = pmalloc(10 + gpdb_dir_sz + strlen(IPC_CLIENT_DIR));
 			sprintf(volumes[i], " %c\"%s:%s:rw\"", comma, *uds_dir, IPC_CLIENT_DIR);
             totallen += strlen(volumes[i]);

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -47,6 +47,6 @@ typedef struct plcContainerConf {
 Datum refresh_plcontainer_config(PG_FUNCTION_ARGS);
 Datum show_plcontainer_config(PG_FUNCTION_ARGS);
 plcContainerConf *plc_get_container_config(char *name);
-char *get_sharing_options(plcContainerConf *conf, int container_slot, bool *has_error);
+char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_slot, bool *has_error);
 
 #endif /* PLC_CONFIGURATION_H */

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -47,6 +47,6 @@ typedef struct plcContainerConf {
 Datum refresh_plcontainer_config(PG_FUNCTION_ARGS);
 Datum show_plcontainer_config(PG_FUNCTION_ARGS);
 plcContainerConf *plc_get_container_config(char *name);
-char *get_sharing_options(plcContainerConf *conf, char **uds_dir, int container_slot, bool *has_error);
+char *get_sharing_options(plcContainerConf *conf, int container_slot, bool *has_error, char **uds_dir);
 
 #endif /* PLC_CONFIGURATION_H */

--- a/src/plc_docker_api_common.h
+++ b/src/plc_docker_api_common.h
@@ -25,7 +25,7 @@ typedef struct {
     int     status;
 } plcCurlBuffer;
 
-int plc_docker_create_container(plcContainerConf *conf, char **name, int container_slot);
+int plc_docker_create_container(plcContainerConf *conf, char **name, char **uds_dir, int container_slot);
 int plc_docker_start_container(char *name);
 int plc_docker_kill_container(char *name);
 int plc_docker_inspect_container(char *name, char **element, plcInspectionMode type);

--- a/src/plc_docker_api_common.h
+++ b/src/plc_docker_api_common.h
@@ -25,7 +25,7 @@ typedef struct {
     int     status;
 } plcCurlBuffer;
 
-int plc_docker_create_container(plcContainerConf *conf, char **name, char **uds_dir, int container_slot);
+int plc_docker_create_container(plcContainerConf *conf, char **name, int container_slot, char **uds_dir);
 int plc_docker_start_container(char *name);
 int plc_docker_kill_container(char *name);
 int plc_docker_inspect_container(char *name, char **element, plcInspectionMode type);

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -163,7 +163,7 @@ cleanup:
     return buffer;
 }
 
-int plc_docker_create_container(plcContainerConf *conf, char **name, char **uds_dir, int container_id) {
+int plc_docker_create_container(plcContainerConf *conf, char **name, int container_id, char **uds_dir) {
     char *createRequest =
             "{\n"
             "    \"AttachStdin\": false,\n"
@@ -181,7 +181,7 @@ int plc_docker_create_container(plcContainerConf *conf, char **name, char **uds_
             "    }\n"
             "}\n";
 	bool  has_error;
-    char *volumeShare = get_sharing_options(conf, uds_dir, container_id, &has_error);
+    char *volumeShare = get_sharing_options(conf, container_id, &has_error, uds_dir);
     char *messageBody = NULL;
     plcCurlBuffer *response = NULL;
     int res = 0;

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -163,7 +163,7 @@ cleanup:
     return buffer;
 }
 
-int plc_docker_create_container(plcContainerConf *conf, char **name, int container_id) {
+int plc_docker_create_container(plcContainerConf *conf, char **name, char **uds_dir, int container_id) {
     char *createRequest =
             "{\n"
             "    \"AttachStdin\": false,\n"
@@ -181,7 +181,7 @@ int plc_docker_create_container(plcContainerConf *conf, char **name, int contain
             "    }\n"
             "}\n";
 	bool  has_error;
-    char *volumeShare = get_sharing_options(conf, container_id, &has_error);
+    char *volumeShare = get_sharing_options(conf, uds_dir, container_id, &has_error);
     char *messageBody = NULL;
     plcCurlBuffer *response = NULL;
     int res = 0;


### PR DESCRIPTION
QE may correspond to many containers, and cleanup process will remove
the domain socket file asynchronously. We need to separate domain socket
file for different containers.