### PR TITLE
Add plcontainer uninstall sql file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ install-extra:
 	$(INSTALL_PROGRAM) '$(MGMTDIR)/bin/plcontainer'                      '$(DESTDIR)$(bindir)/plcontainer'
 	$(INSTALL_DATA)    '$(MGMTDIR)/config/plcontainer_configuration.xml' '$(PLCONTAINERDIR)'
 	$(INSTALL_DATA)    '$(MGMTDIR)/sql/plcontainer_install.sql'          '$(PLCONTAINERDIR)'
+	$(INSTALL_DATA)    '$(MGMTDIR)/sql/plcontainer_uninstall.sql'        '$(PLCONTAINERDIR)'
 
 .PHONY: install-clients
 install-clients: clients

--- a/management/sql/plcontainer_uninstall.sql
+++ b/management/sql/plcontainer_uninstall.sql
@@ -1,0 +1,10 @@
+-- Uninstalling PL/Container trusted language support
+
+DROP VIEW plcontainer_refresh_config;
+DROP VIEW plcontainer_show_config;
+
+DROP FUNCTION plcontainer_refresh_local_config(verbose bool);
+DROP FUNCTION plcontainer_show_local_config();
+
+DROP LANGUAGE plcontainer CASCADE;
+DROP FUNCTION plcontainer_call_handler();

--- a/management/sql/plcontainer_uninstall.sql
+++ b/management/sql/plcontainer_uninstall.sql
@@ -1,10 +1,10 @@
 -- Uninstalling PL/Container trusted language support
 
-DROP VIEW plcontainer_refresh_config;
-DROP VIEW plcontainer_show_config;
+DROP VIEW IF EXISTS plcontainer_refresh_config;
+DROP VIEW IF EXISTS plcontainer_show_config;
 
-DROP FUNCTION plcontainer_refresh_local_config(verbose bool);
-DROP FUNCTION plcontainer_show_local_config();
+DROP FUNCTION IF EXISTS plcontainer_refresh_local_config(verbose bool);
+DROP FUNCTION IF EXISTS plcontainer_show_local_config();
 
-DROP LANGUAGE plcontainer CASCADE;
-DROP FUNCTION plcontainer_call_handler();
+DROP LANGUAGE IF EXISTS plcontainer CASCADE;
+DROP FUNCTION IF EXISTS plcontainer_call_handler();


### PR DESCRIPTION
Users should be noticed that once they run this SQL file, ALL the plcontainer language FUNCTIONS will be dropped cascade.