### PR TITLE
Refactor Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ ifeq ($(RHEL_MAJOR_OS), 6)
   override CFLAGS +=  -DDOCKER_API_LOW
 endif
 
-all: all-lib
+all: all-lib build-clients
+	@echo "Build PL/Container Done."
 
-install: installdirs install-lib install-extra install-clients
+install: all installdirs install-lib install-extra install-clients
 
 clean: clean-clients
 
@@ -66,21 +67,19 @@ installdirs: installdirs-lib
 	$(MKDIR_P) '$(DESTDIR)$(bindir)'
 	$(MKDIR_P) '$(PLCONTAINERDIR)'
 
-.PHONY: uninstall
 uninstall: uninstall-lib
 	rm -f '$(DESTDIR)$(bindir)/plcontainer'
 	rm -rf '$(PLCONTAINERDIR)'
 
 .PHONY: install-extra
 install-extra: installdirs
-	# Management
 	$(INSTALL_PROGRAM) '$(MGMTDIR)/bin/plcontainer'                      '$(DESTDIR)$(bindir)/plcontainer'
 	$(INSTALL_DATA)    '$(MGMTDIR)/config/plcontainer_configuration.xml' '$(PLCONTAINERDIR)/'
 	$(INSTALL_DATA)    '$(MGMTDIR)/sql/plcontainer_install.sql'          '$(PLCONTAINERDIR)/'
 	$(INSTALL_DATA)    '$(MGMTDIR)/sql/plcontainer_uninstall.sql'        '$(PLCONTAINERDIR)/'
 
 .PHONY: install-clients
-install-clients: clients
+install-clients: build-clients
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/pyclient'
 	$(MKDIR_P) '$(DESTDIR)$(bindir)/rclient'
 	cp $(PYCLIENTDIR)/* $(DESTDIR)$(bindir)/pyclient
@@ -90,20 +89,10 @@ install-clients: clients
 installcheck:
 	$(MAKE) -C tests tests
 
-.PHONY: clients
-clients:
-	CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' $(MAKE) -C $(SRCDIR)/pyclient
-	CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' $(MAKE) -C $(SRCDIR)/rclient
-	touch $(COMMONDIR)/clients_timestamp
-
-all-lib: check-clients-make
-	@echo "Build PL/Container Done."
-
-.PHONY: check-clients-make
-check-clients-make:
-	if [ -f $(COMMONDIR)/clients_timestamp ]; then \
-	    rm $(COMMONDIR)/clients_timestamp && $(MAKE) clean ; \
-	fi
+.PHONY: build-clients
+build-clients:
+	CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' $(MAKE) -C $(SRCDIR)/pyclient all
+	CC='$(CC)' CFLAGS='$(CFLAGS)' CPPFLAGS='$(CPPFLAGS)' $(MAKE) -C $(SRCDIR)/rclient all
 
 .PHONY: clean-clients
 clean-clients:

--- a/src/common/comm_utils.c
+++ b/src/common/comm_utils.c
@@ -62,6 +62,10 @@ static void sigsegv_handler() {
 	size = backtrace(stack, 100);
 	lprintf(LOG, "signal SIGSEGV was captured. Stack:");
 	fflush(stdout);
+
+	/* Do not call backtrace_symbols() since it calls malloc(3) which is not
+	 * async signal safe.
+	 */
 	backtrace_symbols_fd(stack, size, STDERR_FILENO);
 	fflush(stderr);
 

--- a/src/pyclient/Makefile
+++ b/src/pyclient/Makefile
@@ -14,43 +14,42 @@ ifeq ($(PYTHON),)
 endif
 
 # Python build flags
-#PYTHON_CFLAGS = $(shell pkg-config --cflags python-2.7)
-#PYTHON_LDFLAGS = $(shell pkg-config --libs python-2.7)
-PYTHON_CFLAGS = $(shell $(PYTHON) -c "from distutils import sysconfig; import sys; sys.stdout.write('-I' + sysconfig.get_python_inc())")
-PYTHON_LDFLAGS = $(shell $(PYTHON) -c "from distutils import sysconfig; import sys; sys.stdout.write(sysconfig.get_config_var('BLDLIBRARY'))")
+#CLIENT_CFLAGS = $(shell pkg-config --cflags python-2.7)
+#CLIENT_LDFLAGS = $(shell pkg-config --libs python-2.7)
+CLIENT_CFLAGS = $(shell $(PYTHON) -c "from distutils import sysconfig; import sys; sys.stdout.write('-I' + sysconfig.get_python_inc())")
+CLIENT_LDFLAGS = $(shell $(PYTHON) -c "from distutils import sysconfig; import sys; sys.stdout.write(sysconfig.get_config_var('BLDLIBRARY'))")
 
 override CFLAGS += $(CUSTOMFLAGS) -I$(PLCONTAINER_DIR)/ -DCOMM_STANDALONE -Wall -Wextra -Werror
 
+CLIENT = pyclient
 common_src = $(shell find $(PLCONTAINER_DIR)/common -name "*.c")
-common_objs = $(foreach src,$(common_src),$(subst .c,.o,$(src)))
-python_src = $(shell find . -name "*.c")
-python_objs = $(foreach src,$(python_src),$(subst .c,.o,$(src)))
-
-PYTHONCLIENT=pyclient
+common_objs = $(foreach src,$(common_src),$(subst .c,.$(CLIENT).o,$(src)))
+client_src = $(shell find . -name "*.c")
+client_objs = $(foreach src,$(client_src),$(subst .c,.o,$(src)))
 
 .PHONY: default
-default: clean all
+default: all
 
-.PHONY: clean_common
-clean_common:
-	rm -f $(common_objs)
+$(common_objs): %.$(CLIENT).o: %.c
+	$(CC) $(CLIENT_CFLAGS) $(CFLAGS) -c -o $@ $^
 
-%.o: %.c
-	$(CC) $(PYTHON_CFLAGS) $(CFLAGS) -c -o $@ $^
+$(client_objs): %.o: %.c
+	$(CC) $(CLIENT_CFLAGS) $(CFLAGS) -c -o $@ $^
 
-client: $(python_objs) $(common_objs)
-	LIBRARY_PATH=$(LD_LIBRARY_PATH) $(CC) -o $(PYTHONCLIENT) $^ $(PYTHON_LDFLAGS) $(LIBS)
-	cp $(PYTHONCLIENT) bin
+build: $(client_objs) $(common_objs)
+	LIBRARY_PATH=$(LD_LIBRARY_PATH) $(CC) -o $(CLIENT) $^ $(CLIENT_LDFLAGS) $(LIBS)
+	cp $(CLIENT) bin
 
 .PHONY: debug
 debug: CUSTOMFLAGS = -D_DEBUG_CLIENT -g -O0
-debug: client
+debug: build
 
 .PHONY: all
 all: CUSTOMFLAGS = -O3 -g
-all: client
+all: build
 
-clean: clean_common
+distclean clean:
+	rm -f $(common_objs)
 	rm -f *.o
-	rm -f $(PYTHONCLIENT)
-	rm -f bin/$(PYTHONCLIENT)
+	rm -f $(CLIENT)
+	rm -f bin/$(CLIENT)


### PR DESCRIPTION
Avoid object file conflicts under common path when compiling both plcontainer and clients.
Allow -jN.

Now we do not save object files under src/common after building.