### PR TITLE
Add stress test cases for pl/container

### DIFF
--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -153,7 +153,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 			gettimeofday(&end_time, NULL);
 			elapsed_us =
 				((uint64)end_time.tv_sec) * 1000000 + end_time.tv_usec -
-				((uint64)start_time.tv_sec) * 1000000 + start_time.tv_usec;
+				((uint64)start_time.tv_sec) * 1000000 - start_time.tv_usec;
 
 			snprintf(api_error_message, sizeof(api_error_message),
 					"PL/Container libcurl returns code %d, error '%s'", res,
@@ -162,7 +162,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 
 			elog(LOG, "Curl Request with type: %d, url: %s", cType, fullurl);
 			elog(LOG, "Curl Request with http body: %s\n", body);
-			elog(LOG, "Curl Request costs " UINT64_FORMAT "us", elapsed_us);
+			elog(LOG, "Curl Request costs " UINT64_FORMAT "ms", elapsed_us/1000);
 
 			goto cleanup;
         } else {

--- a/stress/concurrent_1.sql
+++ b/stress/concurrent_1.sql
@@ -1,0 +1,2 @@
+SELECT count(r_function_1(num)) from NUM_OF_LOOPS;
+SELECT count(python_function_1(num)) from NUM_OF_LOOPS;

--- a/stress/concurrent_2.sql
+++ b/stress/concurrent_2.sql
@@ -1,0 +1,2 @@
+SELECT r_function_2(2);
+SELECT python_function_2(2);

--- a/stress/concurrent_3.sql
+++ b/stress/concurrent_3.sql
@@ -1,0 +1,2 @@
+SELECT count(python_function_3(num)) from NUM_OF_LOOPS;
+SELECT count(r_function_3(num)) from NUM_OF_LOOPS;

--- a/stress/concurrent_4.sql
+++ b/stress/concurrent_4.sql
@@ -1,0 +1,2 @@
+SELECT count(r_function_4(num)) from NUM_OF_LOOPS;
+SELECT count(python_function_4(num)) from NUM_OF_LOOPS;

--- a/stress/concurrent_5.sql
+++ b/stress/concurrent_5.sql
@@ -1,0 +1,2 @@
+SELECT count(python_function_5(num)) from NUM_OF_LOOPS;
+SELECT count(r_function_5(num)) from NUM_OF_LOOPS;

--- a/stress/prepare_concurrent.sql
+++ b/stress/prepare_concurrent.sql
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION r_function_1(num int) RETURNS int4 AS $$
+# container: plc_r_shared
+a <- matrix(rnorm(200), ncol=10, nrow=20)
+b <- matrix(rnorm(200), ncol=20, nrow=10)
+a %*% b
+return (num)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION r_function_2(num int) RETURNS int4 AS $$
+# container: plc_r_shared
+for (i in 1:100){
+    a <- pg.spi.exec("select count(*) from NUM_OF_LOOPS where num < 5")
+}
+return (num)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION r_function_3(num int) RETURNS int4 AS $$
+# container: plc_r_shared
+a <- 0
+for (i in 1:10000){
+  a <- a + num
+}
+return (a)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION r_function_4(num int) RETURNS int4 AS $$
+# container: plc_r_shared
+return (num * 2)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION r_function_5(num int) RETURNS int4 AS $$
+# container: plc_r_shared
+return (num + 1)
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION python_function_1(num int) RETURNS int4 AS $$
+# container: plc_python_shared
+import numpy
+a = numpy.mat(numpy.random.randint(200,size=(10,20)))
+b = numpy.mat(numpy.random.randint(200,size=(20,10)))
+a*b
+return num
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION python_function_2(num int) RETURNS int4 AS $$
+# container: plc_python_shared
+for i in range(1, 500):
+    a = plpy.execute("select count(*) from NUM_OF_LOOPS where num < 5") 
+return num
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION python_function_3(num int) RETURNS int4 AS $$
+# container: plc_python_shared
+a = 0
+for i in range(1, 10000):
+    a = a + num 
+return a
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION python_function_4(num int) RETURNS int4 AS $$
+# container: plc_python_shared
+import time
+return num * 2
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION python_function_5(num int) RETURNS int4 AS $$
+# container: plc_python_shared
+return num + 1
+$$ LANGUAGE plcontainer;
+
+CREATE TABLE NUM_OF_LOOPS (num int, aux int);
+INSERT into NUM_OF_LOOPS (num, aux) select trunc(random() * 120 + 1) as num, aux from generate_series(1,2000) as aux;

--- a/stress/test_concurrent.sh
+++ b/stress/test_concurrent.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# The number of connection x 5
+NUM_CONN=$(($1))
+
+# The number of iteration  
+NUM_ITER=$(($2))
+
+create_db (){
+  echo "Create DB...."
+  dropdb stress_test  
+  createdb stress_test
+  rm -rf log
+  mkdir -p log
+  rm results.log
+  psql stress_test -f $GPHOME/share/postgresql/plcontainer/plcontainer_install.sql
+  psql stress_test -f prepare_concurrent.sql
+  echo "Create DB finished"
+}
+
+# the hostfile need to be existed, and contains all hosts include both sements and master
+remove_db (){
+  echo "Clean DB..."
+  dropdb stress_test
+  gpstop -arf
+  gpssh -f /home/gpadmin/env/hostfile "docker ps -a | awk '{print \$1}' | xargs docker rm -f"
+  gpssh -f /home/gpadmin/env/hostfile "rm -rf /tmp/plcontainer.*"
+  echo "Clean DB finished"
+}
+
+# When the number of connections is set to a high number, be care of the size of swap memory.
+# Otherwise, container will not be able to start and docker may hang.
+test_concurrent () { 
+  for ((i=1; i<=$NUM_CONN; i++)); do
+    echo "Test $i has started"
+    PSQL_LIST=""
+    for ((j=1; j<=5; j++)); do 
+      psql stress_test -f concurrent_${j}.sql >> log/test_${j}_${i}.log & pid=$!
+      PSQL_LIST+=" $pid"
+    done
+  done
+  trap "kill -9 $PSQL_LIST" SIGINT
+  wait $PSQL_LIST
+}
+
+run_concurrent_job () {
+  for ((m=1; m<=$NUM_ITER; m++)); do
+    echo "---------------------------------"
+    echo "The $m ITER has started"
+    time test_concurrent
+    echo "The $m ITER has done"
+    echo "---------------------------------"
+    echo ""
+  done
+  for ((j=1; j<=$NUM_CONN; j++)); do
+    for ((k=1; k<=5; k++)); do
+      cat log/test_${k}_${j}.log >> results.log
+    done
+  done
+}
+
+if [ $# != 2 ]; then
+    echo "Usage: ./test_concurrent.sh num_of_connection num_of_iteration"
+    exit 1
+fi
+if [ -z "$GPHOME" ]; then
+    echo "Need to source greenplum_path.sh before running tests"
+    exit 1
+fi
+echo "Tests must run on master node"
+echo "Start to test"
+time create_db
+time run_concurrent_job
+time remove_db
+
+echo "Test finished, please check output results.log, if neither no error message nor container left, it could be considered the tests are passed."


### PR DESCRIPTION
A concurrent stress tests with 5 test cases for both R and Python.
Usage: ./test_concurrent.sh num_of_connection num_of_iteration