### PR TITLE
Setting timeout for libcurl connection and transfer.

### DIFF
--- a/src/containers.h
+++ b/src/containers.h
@@ -13,8 +13,7 @@
 #include "common/comm_connectivity.h"
 #include "plc_configuration.h"
 
-//#define CONTAINER_DEBUG
-#define CONTAINER_CONNECT_TIMEOUT_MS 5000
+#define CONTAINER_CONNECT_TIMEOUT_MS 10000
 
 /* currently the declaration format for the container in function is:
  * #container:name

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -102,6 +102,14 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
         /* Providing a buffer to store errors in */
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
 
+		/* FIXME: Need GUCs for timeout parameter settings? */
+
+		/* Setting timeout for connecting. */
+		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+
+		/* Setting timeout for connecting. */
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 60L);
+
         /* Choosing the right request type */
         switch (cType) {
             case PLC_HTTP_GET:
@@ -164,7 +172,6 @@ cleanup:
 				"Failed to start a curl session for unknown reason");
 		buffer->status = -1;
 	}
-    curl_global_cleanup();
 
     return buffer;
 }


### PR DESCRIPTION
We see docker hang issue in some cases. For such case, we should exit earlier.