### PR TITLE
Enlarge CURLOPT_TIMEOUT for docker api.

### DIFF
--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -108,7 +108,11 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
 
 		/* Setting timeout for connecting. */
-		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+#ifdef DOCKER_API_LOW
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 180L);
+#else
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, 60L);
+#endif
 
         /* Choosing the right request type */
         switch (cType) {


### PR DESCRIPTION
We enlarge this since there are some concerns that docker creation could
be time-consuming on io heavy-load systems. And especially we see
rhel6 tests frequently fail due to time-consuming docker creation.
This setting is mainly to prevent pl/containers from hanging forever so
a larger timeout should be fine.

This patch also changes some misleading constant definition names.