### PR TITLE
Show runtime configurations before running tests.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,9 +24,9 @@ tests:
 	@echo "runtime configurations soon. If there is configuration missing,"
 	@echo "please refer plcontainer script concourse/scripts/run_plcontainer_tests.sh"
 	@echo "as example to learn how to set up those configurations"
-	plcontainer runtime-show -r plc_python_shared >/dev/null
-	plcontainer runtime-show -r plc_r_shared >/dev/null
-	plcontainer runtime-show -r plc_python_network >/dev/null
+	plcontainer runtime-show -r plc_python_shared
+	plcontainer runtime-show -r plc_r_shared
+	plcontainer runtime-show -r plc_python_network
 	PL_TESTDB=$(PL_TESTDB) $(top_builddir)/src/test/regress/pg_regress \
 				--psqldir=$(PSQLDIR) $(REGRESS_OPTS) || if [[ -f regression.diffs ]]; then cat regression.diffs; exit 1; fi
 


### PR DESCRIPTION
In plcontainer utility, the logging of ERROR, CRITICAL kinds of severe
logger level is not set in sys.stderr, so in Makefile, if runtime-show
commands fail, not details will be in output. This is bad for debugging.