### PR TITLE
 Validate runtime configuration file.

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -315,7 +315,7 @@ static char *get_uds_fn(char *uds_dir) {
 	return uds_fn;
 }
 
-plcConn *start_backend(runtimeConf *conf) {
+plcConn *start_backend(runtimeConfEntry *conf) {
 	int port = 0;
 	unsigned int sleepus = 25000;
 	unsigned int sleepms = 0;

--- a/src/containers.h
+++ b/src/containers.h
@@ -27,7 +27,7 @@ char *parse_container_meta(const char *source);
 plcConn *get_container_conn(const char *id);
 
 /* start a new docker container using the given configuration */
-plcConn *start_backend(runtimeConf *conf);
+plcConn *start_backend(runtimeConfEntry *conf);
 
 /* Function deletes all the containers */
 void delete_containers(void);

--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -41,7 +41,7 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
 	}
 }
 
-int plc_backend_create(runtimeConf *conf, char **name, int container_slot, char **uds_dir) {
+int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir) {
 	return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, container_slot, uds_dir) : 0;
 }
 

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -15,7 +15,7 @@
 
 extern char api_error_message[256];
 
-typedef int ( *PLC_FPTR_create)(runtimeConf *conf, char **name, int container_slot, char **uds_dir);
+typedef int ( *PLC_FPTR_create)(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
 
 typedef int ( *PLC_FPTR_start)(const char *name);
 
@@ -49,7 +49,7 @@ enum PLC_BACKEND_TYPE {
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
 /* interface for plc backend*/
-int plc_backend_create(runtimeConf *conf, char **name, int container_slot, char **uds_dir);
+int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
 
 int plc_backend_start(const char *name);
 

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -14,6 +14,12 @@
 #include "plcontainer.h"
 
 #define PLC_PROPERTIES_FILE "plcontainer_configuration.xml"
+#define SHARED_DIR_MAX_LENGTH 512
+#define RUNTIME_ID_MAX_LENGTH 512
+#define IMAGE_NAME_MAX_LENGTH 512
+#define COMMAND_MAX_LENGTH 512
+#define MAX_SHARED_DIR_NUM 16
+#define MAX_EXPECTED_RUNTIME_NUM 32
 
 typedef enum {
 	PLC_ACCESS_READONLY = 0,
@@ -33,16 +39,16 @@ typedef struct plcSharedDir {
 	plcFsAccessMode mode;
 } plcSharedDir;
 
-typedef struct runtimeConf {
-	char *runtimeid;
+typedef struct runtimeConfEntry {
+	char runtimeid[RUNTIME_ID_MAX_LENGTH];
 	char *image;
 	char *command;
 	int memoryMb;
 	int nSharedDirs;
-	plcSharedDir *sharedDirs;
+	plcSharedDir* sharedDirs;
 	bool isNetworkConnection;
 	bool enable_log;
-} runtimeConf;
+} runtimeConfEntry;
 
 /* entrypoint for all plcontainer procedures */
 Datum refresh_plcontainer_config(PG_FUNCTION_ARGS);
@@ -51,8 +57,8 @@ Datum show_plcontainer_config(PG_FUNCTION_ARGS);
 
 Datum containers_summary(PG_FUNCTION_ARGS);
 
-runtimeConf *plc_get_runtime_configuration(char *id);
+runtimeConfEntry *plc_get_runtime_configuration(char *id);
 
-char *get_sharing_options(runtimeConf *conf, int container_slot, bool *has_error, char **uds_dir);
+char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_error, char **uds_dir);
 
 #endif /* PLC_CONFIGURATION_H */

--- a/src/plc_docker_api_common.h
+++ b/src/plc_docker_api_common.h
@@ -25,7 +25,7 @@ typedef struct {
 	int status;
 } plcCurlBuffer;
 
-int plc_docker_create_container(runtimeConf *conf, char **name, int container_slot, char **uds_dir);
+int plc_docker_create_container(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
 
 int plc_docker_start_container(const char *name);
 

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -202,7 +202,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 	return buffer;
 }
 
-int plc_docker_create_container(runtimeConf *conf, char **name, int container_id, char **uds_dir) {
+int plc_docker_create_container(runtimeConfEntry *conf, char **name, int container_id, char **uds_dir) {
 	char *createRequest =
 		"{\n"
 			"    \"AttachStdin\": false,\n"

--- a/src/plc_typeio.c
+++ b/src/plc_typeio.c
@@ -553,7 +553,6 @@ static Datum plc_datum_from_array(char *input, plcTypeInfo *type) {
 	ArrayType *array = NULL;
 	int *lbs = NULL;
 	int i;
-	MemoryContext oldContext;
 	plcArray *arr;
 	char *ptr;
 	int len;
@@ -577,7 +576,6 @@ static Datum plc_datum_from_array(char *input, plcTypeInfo *type) {
 		ptr += len;
 	}
 
-	oldContext = MemoryContextSwitchTo(pl_container_caller_context);
 	array = construct_md_array(elems,
 	                           arr->nulls,
 	                           arr->meta->ndims,
@@ -589,7 +587,6 @@ static Datum plc_datum_from_array(char *input, plcTypeInfo *type) {
 	                           subType->typalign);
 
 	dvalue = PointerGetDatum(array);
-	MemoryContextSwitchTo(oldContext);
 
 	pfree(lbs);
 	pfree(elems);
@@ -603,7 +600,6 @@ static Datum plc_datum_from_udt(char *input, plcTypeInfo *type) {
 	Datum *values;
 	bool *nulls;
 	volatile int i, j;
-	MemoryContext oldContext;
 	plcUDT *udt = (plcUDT *) input;
 
 	/* Build tuple */
@@ -622,11 +618,9 @@ static Datum plc_datum_from_udt(char *input, plcTypeInfo *type) {
 		}
 	}
 
-	oldContext = MemoryContextSwitchTo(pl_container_caller_context);
 	desc = lookup_rowtype_tupdesc(type->typeOid, type->typmod);
 	tuple = heap_form_tuple(desc, values, nulls);
 	ReleaseTupleDesc(desc);
-	MemoryContextSwitchTo(oldContext);
 
 	pfree(values);
 	pfree(nulls);

--- a/src/plcontainer_common.c
+++ b/src/plcontainer_common.c
@@ -11,6 +11,8 @@
 
 #include "plcontainer_common.h"
 
+HTAB *rumtime_conf_table = NULL;
+
 /* Some utility functions
  * They are consistent with upstream plpython.c
  * where the functions are called PLy_free and PLy_malloc.

--- a/src/plcontainer_common.h
+++ b/src/plcontainer_common.h
@@ -9,9 +9,11 @@
 #define PLC_PLCONTAINER_COMMON_H_
 
 #include "fmgr.h"
+#include "utils/hsearch.h"
 #include "utils/resowner.h"
 
-MemoryContext pl_container_caller_context;
+extern HTAB *rumtime_conf_table;
+extern MemoryContext pl_container_caller_context;
 
 /* list of explicit subtransaction data */
 List *explicit_subtransactions;

--- a/tests/wrong_configuration/wrong_conf1.xml
+++ b/tests/wrong_configuration/wrong_conf1.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_r_shared</id>
+        <image>pivotaldata/plcontainer_r_shared:devel</image>
+        <command>/clientdir/rclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+        <setting use_network="yes"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+        <setting use_network="yes"/>
+    </runtime>
+</configuration>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/wrong_configuration/wrong_conf2.xml
+++ b/tests/wrong_configuration/wrong_conf2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_r_shared</id>
+        <image>pivotaldata/plcontainer_r_shared:devel</image>
+        <command>/clientdir/rclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+	<shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+	<shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+        <setting use_network="yes"/>
+    </runtime>
+</configuration>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/wrong_configuration/wrong_conf3.xml
+++ b/tests/wrong_configuration/wrong_conf3.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_r_shared</id>
+        <image>pivotaldata/plcontainer_r_shared:devel</image>
+        <command>/clientdir/rclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+	<image>pivotaldata/plcontainer_python_shared:devel</image>
+	<image>pivotaldata/plcontainer_python:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+	<shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+        <setting use_network="yes"/>
+    </runtime>
+</configuration>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/wrong_configuration/wrong_conf4.xml
+++ b/tests/wrong_configuration/wrong_conf4.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_r_shared</id>
+        <image>pivotaldata/plcontainer_r_shared:devel</image>
+        <command>/clientdir/rclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+	<shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+        <setting use_network="yes"/>
+    </runtime>
+</configuration>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/wrong_configuration/wrong_conf5.xml
+++ b/tests/wrong_configuration/wrong_conf5.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_r_shared</id>
+        <image>pivotaldata/plcontainer_r_shared:devel</image>
+        <command>/clientdir/rclient.sh</command>
+        <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="enable"/>
+    </runtime>
+    <runtime>
+        <id>plc_python_network</id>
+        <image>pivotaldata/plcontainer_python_shared:devel</image>
+        <command>/clientdir/pyclient.sh</command>
+	<shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
+        <setting logs="true"/>
+        <setting use_network="yes"/>
+    </runtime>
+</configuration>
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
We use the HTAB to store the configuration.
And do more check on the conf file.
Some wrong configuration files in placed in tests/wrong_configuration/, since plcontainer runtime-restore will also do checking at python side. we need to copy this wrong conf manually to all the hosts to verify the correctness of this PR. 