### PR TITLE
CI: deprecate CCP remote state path convention

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -32,7 +32,7 @@ ccp_gen_cluster_default_params_anchor: &ccp_gen_cluster_default_params
   AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
   AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
   AWS_DEFAULT_REGION: {{aws-region}}
-  BUCKET_PATH: {{tf-bucket-path-plcontainer}}
+  BUCKET_PATH: clusters/
   BUCKET_NAME: {{tf-bucket-name}}
 
 ccp_options_anchor6: &ccp_options6
@@ -159,20 +159,7 @@ resources:
       # This is not parameterized, on purpose. All tfstates will go to this spot,
       # and different teams will place there clusters' tfstate files under different paths
       bucket: {{tf-bucket-name}}
-      ###########################################################
-      # Two conventions are allowed for bucket_path:            #
-      # 1) Cluster are expected to be destroyed automatically   #
-      #    Toolsmiths will reap old and orphaned clusters       #
-      #                                                         #
-      #      bucket_path: prod/[Pipeline Name]/                 #
-      #                                                         #
-      # 2) Long lived clusters for development.                 #
-      #    The team that creates it is responsible for cluster  #
-      #                                                         #
-      #     bucket_path: dev/[Team Name]/                       #
-      #                                                         #
-      ###########################################################
-      bucket_path: {{tf-bucket-path-plcontainer}}
+      bucket_path: clusters/
 
 # Docker images
 

--- a/concourse/release-pipeline.yml
+++ b/concourse/release-pipeline.yml
@@ -27,7 +27,7 @@ ccp_gen_cluster_default_params_anchor: &ccp_gen_cluster_default_params
   AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
   AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
   AWS_DEFAULT_REGION: {{aws-region}}
-  BUCKET_PATH: {{tf-bucket-path-plcontainer}}
+  BUCKET_PATH: clusters/
   BUCKET_NAME: {{tf-bucket-name}}
 
 ccp_options_anchor6: &ccp_options6
@@ -154,20 +154,7 @@ resources:
       # This is not parameterized, on purpose. All tfstates will go to this spot,
       # and different teams will place there clusters' tfstate files under different paths
       bucket: gpdb5-pipeline-dynamic-terraform
-      ###########################################################
-      # Two conventions are allowed for bucket_path:            #
-      # 1) Cluster are expected to be destroyed automatically   #
-      #    Toolsmiths will reap old and orphaned clusters       #
-      #                                                         #
-      #      bucket_path: prod/[Pipeline Name]/                 #
-      #                                                         #
-      # 2) Long lived clusters for development.                 #
-      #    The team that creates it is responsible for cluster  #
-      #                                                         #
-      #     bucket_path: dev/[Team Name]/                       #
-      #                                                         #
-      ###########################################################
-      bucket_path: {{tf-bucket-path-plcontainer}}
+      bucket_path: clusters/
 
 # Docker images
 


### PR DESCRIPTION
Going forward any pipeline with a terraform resource should specify a
BUCKET_PATH of `clusters/`.

As a static value it can be hardcoded in place of being an interpolated
value from a secrets file.  The key `tf-bucket-path` in any secrets yaml
files is now deprecated and should be removed.

We are dropping the convention where we had teams place their clusters'
tfstate files in a path. In the past this convention was necessary, but
now that we are tagging the clusters with much richer metadata, this
convention is no longer strictly necessary.

Balanced against the need for keeping the bucket organized was the
possibility of two clusters attempting to register their AWS public key
with the same name.  This collision came as a result of the mismatch in
scope.  The terraform resource that provisioned the clusters, and
selected names is only looking in the path given for name collisions,
but the names for AWS keys has to be unique for the account.

By collapsing all of the clusters into an account wide bucket, we will
rely on the terraform resource to check for name conflicts going
forward.

Addresses bug: https://www.pivotaltracker.com/story/show/153928527

Signed-off-by: Kris Macoskey <kmacoskey@pivotal.io>