### PR TITLE
Add CLIENT_UID and CLIENT_GID.

### DIFF
--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -212,6 +212,8 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 			"    \"Cmd\": [\"%s\"],\n"
 			"    \"Env\": [\"EXECUTOR_UID=%d\",\n"
 			"              \"EXECUTOR_GID=%d\",\n"
+			"              \"CLIENT_UID=%d\",\n"
+			"              \"CLIENT_GID=%d\",\n"
 			"              \"DB_USER_NAME=%s\",\n"
 			"              \"DB_NAME=%s\",\n"
 			"              \"DB_QE_PID=%d\",\n"
@@ -255,6 +257,8 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	         conf->command,
 	         getuid(),
 	         getgid(),
+	         getuid() + 1,
+	         getgid() + 1,
 	         username,
 	         dbname,
 	         MyProcPid,


### PR DESCRIPTION
The UID/GID of container process should not be hardcoded as (gpadmin + 1).
We let it be set by the executor side via env variables CLIENT_UID and CLIENT_GID.

Note: CLIENT means python or r, not client for ipc/network application.