### PR TITLE
Enhance logging in plcontainer

### DIFF
--- a/src/common/comm_channel.h
+++ b/src/common/comm_channel.h
@@ -35,9 +35,9 @@ interpreted as representing official policies, either expressed or implied, of t
 //#define PLCONTAINER_CHANNEL_DEBUG
 
 #ifdef PLCONTAINER_CHANNEL_DEBUG
-	#define debug_print(...) lprintf(__VA_ARGS__)
+	#define channel_elog(...) plc_elog(__VA_ARGS__)
 #else
-	#define debug_print(...)
+	#define channel_elog(...)
 #endif
 
 int plcontainer_channel_send(plcConn *conn, plcMessage *msg);

--- a/src/common/comm_messages.c
+++ b/src/common/comm_messages.c
@@ -254,7 +254,7 @@ int plc_get_type_length(plcDatatype dt) {
 			break;
 		case PLC_DATA_ARRAY:
 		default:
-			lprintf(ERROR, "Type %s [%d] cannot be passed plc_get_type_length function",
+			plc_elog(ERROR, "Type %s [%d] cannot be passed plc_get_type_length function",
 				        plc_get_type_name(dt), (int) dt);
 			break;
 	}

--- a/src/common/comm_utils.c
+++ b/src/common/comm_utils.c
@@ -30,7 +30,7 @@ char *plc_top_strdup(char *str) {
 void *pmalloc(size_t size) {
 	void *addr = malloc(size);
 	if (addr == NULL)
-		lprintf(ERROR, "Fail to allocate %ld bytes", (unsigned long) size);
+		plc_elog(ERROR, "Fail to allocate %ld bytes", (unsigned long) size);
 	return addr;
 }
 
@@ -47,7 +47,7 @@ static void set_signal_handler(int signo, int sigflags, signal_handler func) {
 
 	ret = sigaction(signo, &sa, NULL);
 	if (ret < 0) {
-			lprintf(ERROR, "sigaction(%d with flag 0x%x) failed: %s", signo,
+			plc_elog(ERROR, "sigaction(%d with flag 0x%x) failed: %s", signo,
 			        sigflags, strerror(errno));
 		return;
 	}
@@ -60,7 +60,7 @@ static void sigsegv_handler() {
 	int size;
 
 	size = backtrace(stack, 100);
-		lprintf(LOG, "signal SIGSEGV was captured in pl/container. Stack:");
+		plc_elog(LOG, "signal SIGSEGV was captured in pl/container. Stack:");
 	fflush(stdout);
 
 	/* Do not call backtrace_symbols() since it calls malloc(3) which is not

--- a/src/common/comm_utils.h
+++ b/src/common/comm_utils.h
@@ -32,7 +32,7 @@ interpreted as representing official policies, either expressed or implied, of t
 /*
   COMM_STANDALONE should be defined for standalone interpreters
   running inside containers, since they don't have access to postgres
-  symbols. If it was defined, lprintf will print the logs to stdout or
+  symbols. If it was defined, plc_elog will print the logs to stdout or
   in case of an error to stderr. pmalloc, pfree & pstrdup will use the
   std library.
 */
@@ -77,7 +77,7 @@ typedef char bool;
 #define false   ((bool) 0)
 /* End of extraction from c.h */
 
-#define lprintf(lvl, fmt, ...)                                          \
+#define plc_elog(lvl, fmt, ...)                                          \
         do {                                                            \
             FILE *out = stdout;                                         \
             if (lvl >= ERROR) {                                         \
@@ -107,7 +107,7 @@ void set_signal_handlers(void);
 
 #include "postgres.h"
 
-#define lprintf elog
+#define plc_elog(lvl, fmt, ...) elog(lvl, "plcontainer: " fmt, ##__VA_ARGS__);
 #define pmalloc palloc
 
 /* pfree & pstrdup are already defined by postgres */

--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -6,13 +6,14 @@
  */
 
 #include "plc_backend_api.h"
+#include "common/comm_utils.h"
 
 static PLC_FunctionEntriesData CurrentPLCImp;
 
 char api_error_message[256];
 
 /*
- * NOTE: Do not call elog(>=ERROR, ...) in backend api code. Let the callers
+ * NOTE: Do not call plc_elog(>=ERROR, ...) in backend api code. Let the callers
  * handle according to the return value and error message string.
  */
 
@@ -37,7 +38,7 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
 			plc_docker_init(&CurrentPLCImp);
 			break;
 		default:
-			elog(ERROR, "Unsupported plc backend type: %d", imptype);
+			plc_elog(ERROR, "Unsupported plc backend type: %d", imptype);
 	}
 }
 

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -75,7 +75,7 @@ static void init_runtime_configurations() {
 								HASH_ELEM | HASH_FUNCTION);
 
 	if (rumtime_conf_table == NULL) {
-		elog(ERROR, "Error: could not create runtime conf hash table. Check your memory usage.");
+		plc_elog(ERROR, "Error: could not create runtime conf hash table. Check your memory usage.");
 	}
 
 	return ;
@@ -101,7 +101,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 	bool		foundPtr;
 
 	if (rumtime_conf_table == NULL) {
-		elog(ERROR, "Runtime configuration table is not initialized.");
+		plc_elog(ERROR, "Runtime configuration table is not initialized.");
 	}
 
 	PG_TRY();
@@ -115,7 +115,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 			if (cur_node->type == XML_ELEMENT_NODE &&
 					xmlStrcmp(cur_node->name, (const xmlChar *) "id") == 0) {
 				if (id_num++ > 0) {
-					elog(ERROR, "tag <id> must be specified only once in configuartion");
+					plc_elog(ERROR, "tag <id> must be specified only once in configuartion");
 				}
 				value = xmlNodeGetContent(cur_node);
 
@@ -128,7 +128,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 		}
 
 		if (id_num == 0) {
-			elog(ERROR, "tag <id> must be specified in configuartion");
+			plc_elog(ERROR, "tag <id> must be specified in configuartion");
 		}
 
 		/* find the corresponding runtime config*/
@@ -136,7 +136,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 
 		/*check if runtime id already exists in hash table.*/
 		if (foundPtr) {
-			elog(ERROR, "Detecting duplicated runtime id %s in configuration file", runtime_id);
+			plc_elog(ERROR, "Detecting duplicated runtime id %s in configuration file", runtime_id);
 		}
 
 		/* First iteration - parse name, container_id and memory_mb and count the
@@ -190,7 +190,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 						} else if (strcasecmp((char *) value, "disable") == 0) {
 							conf_entry->enable_log = false;
 						} else {
-							elog(ERROR, "SETTING element <log> only accepted \"enable\" or"
+							plc_elog(ERROR, "SETTING element <log> only accepted \"enable\" or"
 								"\"disable\" only, current string is %s", value);
 						}
 						xmlFree((void *) value);
@@ -201,7 +201,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 						validSetting = true;
 						long memorySize = pg_atoi((char *) value, sizeof(int), 0);
 						if (memorySize <= 0) {
-							elog(ERROR, "container memory size could not less 0, current string is %s", value);
+							plc_elog(ERROR, "container memory size could not less 0, current string is %s", value);
 						} else {
 							conf_entry->memoryMb = conf_entry->memoryMb;
 						}
@@ -218,7 +218,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 								 strcasecmp((char *) value, "yes") == 0) {
 							conf_entry->isNetworkConnection = true;
 						} else {
-							elog(ERROR, "SETTING element <use_network> only accepted \"yes\"|\"true\" or"
+							plc_elog(ERROR, "SETTING element <use_network> only accepted \"yes\"|\"true\" or"
 								"\"no\"|\"false\" only, current string is %s", value);
 
 						}
@@ -226,7 +226,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 						value = NULL;
 					}
 					if (!validSetting) {
-						elog(ERROR, "Unrecognized setting options, please check the configuration file: %s", conf_entry->runtimeid);
+						plc_elog(ERROR, "Unrecognized setting options, please check the configuration file: %s", conf_entry->runtimeid);
 					}
 
 				}
@@ -238,7 +238,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 
 				/* If the tag is not known - we raise the related error */
 				if (processed == 0) {
-					elog(ERROR, "Unrecognized element '%s' inside of container specification",
+					plc_elog(ERROR, "Unrecognized element '%s' inside of container specification",
 						 cur_node->name);
 				}
 
@@ -251,17 +251,17 @@ static void parse_runtime_configuration(xmlNode *node) {
 		}
 
 		if (image_num > 1) {
-			elog(ERROR, "There are more than one 'image' subelement in a runtime element %s", conf_entry->runtimeid);
+			plc_elog(ERROR, "There are more than one 'image' subelement in a runtime element %s", conf_entry->runtimeid);
 		}
 		else if (image_num < 1) {
-			elog(ERROR, "Lack of 'image' subelement in a runtime element %s", conf_entry->runtimeid);
+			plc_elog(ERROR, "Lack of 'image' subelement in a runtime element %s", conf_entry->runtimeid);
 		}
 
 		if (command_num > 1) {
-			elog(ERROR, "There are more than one 'command' subelement in a runtime element %s", conf_entry->runtimeid);
+			plc_elog(ERROR, "There are more than one 'command' subelement in a runtime element %s", conf_entry->runtimeid);
 		}
 		else if (command_num < 1) {
-			elog(ERROR, "Lack of 'command' subelement in a runtime element %s", conf_entry->runtimeid);
+			plc_elog(ERROR, "Lack of 'command' subelement in a runtime element %s", conf_entry->runtimeid);
 		}
 
 		/* Process the shared directories */
@@ -279,14 +279,14 @@ static void parse_runtime_configuration(xmlNode *node) {
 
 					value = xmlGetProp(cur_node, (const xmlChar *) "host");
 					if (value == NULL) {
-						elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
+						plc_elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
 							" 'host' that is not found: %s", conf_entry->runtimeid);
 					}
 					conf_entry->sharedDirs[i].host = plc_top_strdup((char *) value);
 					xmlFree((void *) value);
 					value = xmlGetProp(cur_node, (const xmlChar *) "container");
 					if (value == NULL) {
-						elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
+						plc_elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
 							" 'container' that is not found: %s", conf_entry->runtimeid);
 					}
 					/* Shared folders will not be created a lot, so using array to search duplicated
@@ -294,7 +294,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 					 * */
 					for (j =0; j< i; j++) {
 						if (strcasecmp((char *) value, conf_entry->sharedDirs[j].container) == 0) {
-							elog(ERROR, "Container path cannot be the same in 'shared_directory' element "
+							plc_elog(ERROR, "Container path cannot be the same in 'shared_directory' element "
 									"in the runtime %s", conf_entry->runtimeid);
 						}
 					}
@@ -302,14 +302,14 @@ static void parse_runtime_configuration(xmlNode *node) {
 					xmlFree((void *) value);
 					value = xmlGetProp(cur_node, (const xmlChar *) "access");
 					if (value == NULL) {
-						elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
+						plc_elog(ERROR, "Configuration tag 'shared_directory' has a mandatory element"
 							" 'access' that is not found: %s", conf_entry->runtimeid);
 					} else if (strcmp((char *) value, "ro") == 0) {
 						conf_entry->sharedDirs[i].mode = PLC_ACCESS_READONLY;
 					} else if (strcmp((char *) value, "rw") == 0) {
 						conf_entry->sharedDirs[i].mode = PLC_ACCESS_READWRITE;
 					} else {
-						elog(ERROR, "Directory access mode should be either 'ro' or 'rw', passed value is '%s': %s", value, conf_entry->runtimeid);
+						plc_elog(ERROR, "Directory access mode should be either 'ro' or 'rw', passed value is '%s': %s", value, conf_entry->runtimeid);
 					}
 					xmlFree((void *) value);
 					value = NULL;
@@ -345,7 +345,7 @@ static void get_runtime_configurations(xmlNode *node) {
 
 	/* Validation that the root node matches the expected specification */
 	if (xmlStrcmp(node->name, (const xmlChar *) "configuration") != 0) {
-		elog(ERROR, "Wrong XML configuration provided. Expected 'configuration'"
+		plc_elog(ERROR, "Wrong XML configuration provided. Expected 'configuration'"
 			" as root element, got '%s' instead", node->name);
 	}
 
@@ -359,7 +359,7 @@ static void get_runtime_configurations(xmlNode *node) {
 
 	/* If no container definitions found - error */
 	if (hash_get_num_entries(rumtime_conf_table) == 0) {
-		elog(ERROR, "Did not find a single 'runtime' declaration in configuration");
+		plc_elog(ERROR, "Did not find a single 'runtime' declaration in configuration");
 	}
 
 	return ;
@@ -394,19 +394,19 @@ static void print_runtime_configurations() {
 
 		while ((conf_entry = (runtimeConfEntry *) hash_seq_search(&hash_status)) != NULL)
 		{
-			elog(INFO, "Container '%s' configuration", conf_entry->runtimeid);
-			elog(INFO, "    image = '%s'", conf_entry->image);
-			elog(INFO, "    memory_mb = '%d'", conf_entry->memoryMb);
-			elog(INFO, "    use network = '%s'", conf_entry->isNetworkConnection ? "yes" : "no");
-			elog(INFO, "    enable log  = '%s'", conf_entry->enable_log ? "yes" : "no");
+			plc_elog(INFO, "Container '%s' configuration", conf_entry->runtimeid);
+			plc_elog(INFO, "    image = '%s'", conf_entry->image);
+			plc_elog(INFO, "    memory_mb = '%d'", conf_entry->memoryMb);
+			plc_elog(INFO, "    use network = '%s'", conf_entry->isNetworkConnection ? "yes" : "no");
+			plc_elog(INFO, "    enable log  = '%s'", conf_entry->enable_log ? "yes" : "no");
 			for (j = 0; j < conf_entry->nSharedDirs; j++) {
-				elog(INFO, "    shared directory from host '%s' to container '%s'",
+				plc_elog(INFO, "    shared directory from host '%s' to container '%s'",
 					 conf_entry->sharedDirs[j].host,
 					 conf_entry->sharedDirs[j].container);
 				if (conf_entry->sharedDirs[j].mode == PLC_ACCESS_READONLY) {
-					elog(INFO, "        access = readonly");
+					plc_elog(INFO, "        access = readonly");
 				} else {
-					elog(INFO, "        access = readwrite");
+					plc_elog(INFO, "        access = readwrite");
 				}
 			}
 		}
@@ -432,7 +432,7 @@ static int plc_refresh_container_config(bool verbose) {
 	{
 		doc = xmlReadFile(filename, NULL, 0);
 		if (doc == NULL) {
-			elog(ERROR, "Error: could not parse file %s, wrongly formatted XML or missing configuration file\n", filename);
+			plc_elog(ERROR, "Error: could not parse file %s, wrongly formatted XML or missing configuration file\n", filename);
 			return -1;
 		}
 
@@ -636,7 +636,7 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 		container_list = json_tokener_parse(json_result);
 
 		if (container_list == NULL) {
-			elog(ERROR, "Parse JSON object error, cannot get the containers summary");
+			plc_elog(ERROR, "Parse JSON object error, cannot get the containers summary");
 		}
 
 		arraylen = json_object_array_length(container_list);
@@ -697,23 +697,23 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 
 			containerObj = json_object_array_get_idx(container_list, call_cntr);
 			if (containerObj == NULL) {
-				elog(ERROR, "Not a valid container.");
+				plc_elog(ERROR, "Not a valid container.");
 			}
 
 			struct json_object *statusObj = NULL;
 			if (!json_object_object_get_ex(containerObj, "Status", &statusObj)) {
-				elog(ERROR, "failed to get json \"Status\" field.");
+				plc_elog(ERROR, "failed to get json \"Status\" field.");
 			}
 			const char *statusStr = json_object_get_string(statusObj);
 			struct json_object *labelObj = NULL;
 			if (!json_object_object_get_ex(containerObj, "Labels", &labelObj)) {
-				elog(ERROR, "failed to get json \"Labels\" field.");
+				plc_elog(ERROR, "failed to get json \"Labels\" field.");
 			}
 			struct json_object *ownerObj = NULL;
 			if (!json_object_object_get_ex(labelObj, "owner", &ownerObj)) {
 				funcctx->call_cntr++;
 				call_cntr++;
-				elog(LOG, "failed to get json \"owner\" field. Maybe this container is not started by PL/Container");
+				plc_elog(LOG, "failed to get json \"owner\" field. Maybe this container is not started by PL/Container");
 				continue;
 			}
 			const char *ownerStr = json_object_get_string(ownerObj);
@@ -721,7 +721,7 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 			if (strcmp(ownerStr, username) != 0 && superuser() == false) {
 				funcctx->call_cntr++;
 				call_cntr++;
-				elog(DEBUG1, "Current username %s (not super user) is not match conatiner owner %s, skip",
+				plc_elog(DEBUG1, "Current username %s (not super user) is not match conatiner owner %s, skip",
 					 username, ownerStr);
 				continue;
 			}
@@ -730,13 +730,13 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 			if (!json_object_object_get_ex(labelObj, "dbid", &dbidObj)) {
 				funcctx->call_cntr++;
 				call_cntr++;
-				elog(LOG, "failed to get json \"dbid\" field. Maybe this container is not started by PL/Container");
+				plc_elog(LOG, "failed to get json \"dbid\" field. Maybe this container is not started by PL/Container");
 				continue;
 			}
 			const char *dbidStr = json_object_get_string(dbidObj);
 			struct json_object *idObj = NULL;
 			if (!json_object_object_get_ex(containerObj, "Id", &idObj)) {
-				elog(ERROR, "failed to get json \"Id\" field.");
+				plc_elog(ERROR, "failed to get json \"Id\" field.");
 			}
 			const char *idStr = json_object_get_string(idObj);
 
@@ -744,11 +744,11 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 			containerStateObj = json_tokener_parse(containerState);
 			struct json_object *memoryObj = NULL;
 			if (!json_object_object_get_ex(containerStateObj, "memory_stats", &memoryObj)) {
-				elog(ERROR, "failed to get json \"memory_stats\" field.");
+				plc_elog(ERROR, "failed to get json \"memory_stats\" field.");
 			}
 			struct json_object *memoryUsageObj = NULL;
 			if (!json_object_object_get_ex(memoryObj, "usage", &memoryUsageObj)) {
-				elog(LOG, "failed to get json \"usage\" field.");
+				plc_elog(LOG, "failed to get json \"usage\" field.");
 			} else {
 				containerMemoryUsage = json_object_get_int64(memoryUsageObj) / 1024;
 			}

--- a/src/plc_docker_common.c
+++ b/src/plc_docker_common.c
@@ -6,17 +6,18 @@
  */
 
 #include "plc_docker_common.h"
+#include "common/comm_utils.h"
 #include "regex/regex.h"
 
 int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
-	elog(DEBUG1, "plcontainer: docker_inspect_string:%s", buf);
+	plc_elog(DEBUG1, "plcontainer: docker_inspect_string:%s", buf);
 	struct json_object *response = json_tokener_parse(buf);
 	if (response == NULL)
 		return -1;
 	if (type == PLC_INSPECT_NAME) {
 		struct json_object *nameidObj = NULL;
 		if (!json_object_object_get_ex(response, "Id", &nameidObj)) {
-			elog(WARNING, "failed to get json \"Id\" field.");
+			plc_elog(WARNING, "failed to get json \"Id\" field.");
 			return -1;
 		}
 		const char *namestr = json_object_get_string(nameidObj);
@@ -25,21 +26,21 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 	} else if (type == PLC_INSPECT_PORT) {
 		struct json_object *NetworkSettingsObj = NULL;
 		if (!json_object_object_get_ex(response, "NetworkSettings", &NetworkSettingsObj)) {
-			elog(WARNING, "failed to get json \"NetworkSettings\" field.");
+			plc_elog(WARNING, "failed to get json \"NetworkSettings\" field.");
 			return -1;
 		}
 		struct json_object *PortsObj = NULL;
 		if (!json_object_object_get_ex(NetworkSettingsObj, "Ports", &PortsObj)) {
-			elog(WARNING, "failed to get json \"Ports\" field.");
+			plc_elog(WARNING, "failed to get json \"Ports\" field.");
 			return -1;
 		}
 		struct json_object *HostPortArray = NULL;
 		if (!json_object_object_get_ex(PortsObj, "8080/tcp", &HostPortArray)) {
-			elog(WARNING, "failed to get json \"HostPortArray\" field.");
+			plc_elog(WARNING, "failed to get json \"HostPortArray\" field.");
 			return -1;
 		}
 		if (json_object_get_type(HostPortArray) != json_type_array) {
-			elog(WARNING, "no element found in json \"HostPortArray\" field.");
+			plc_elog(WARNING, "no element found in json \"HostPortArray\" field.");
 			return -1;
 		}
 		int arraylen = json_object_array_length(HostPortArray);
@@ -47,12 +48,12 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 			struct json_object *PortBindingObj = NULL;
 			PortBindingObj = json_object_array_get_idx(HostPortArray, i);
 			if (PortBindingObj == NULL) {
-				elog(WARNING, "failed to get json \"PortBinding\" field.");
+				plc_elog(WARNING, "failed to get json \"PortBinding\" field.");
 				return -1;
 			}
 			struct json_object *HostPortObj = NULL;
 			if (!json_object_object_get_ex(PortBindingObj, "HostPort", &HostPortObj)) {
-				elog(WARNING, "failed to get json \"HostPort\" field.");
+				plc_elog(WARNING, "failed to get json \"HostPort\" field.");
 				return -1;
 			}
 			const char *HostPortStr = json_object_get_string(HostPortObj);
@@ -62,13 +63,13 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 	} else if (type == PLC_INSPECT_STATUS) {
 		struct json_object *StateObj = NULL;
 		if (!json_object_object_get_ex(response, "State", &StateObj)) {
-			elog(WARNING, "failed to get json \"State\" field.");
+			plc_elog(WARNING, "failed to get json \"State\" field.");
 			return -1;
 		}
 #ifdef DOCKER_API_LOW
 		struct json_object *RunningObj = NULL;
 		if (!json_object_object_get_ex(StateObj, "Running", &RunningObj)) {
-			elog(WARNING, "failed to get json \"Running\" field.");
+			plc_elog(WARNING, "failed to get json \"Running\" field.");
 			return -1;
 		}
 		const char *RunningStr = json_object_get_string(RunningObj);
@@ -77,7 +78,7 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 #else
 		struct json_object *StatusObj = NULL;
 		if (!json_object_object_get_ex(StateObj, "Status", &StatusObj)) {
-			elog(WARNING, "failed to get json \"Status\" field.");
+			plc_elog(WARNING, "failed to get json \"Status\" field.");
 			return -1;
 		}
 		const char *StatusStr = json_object_get_string(StatusObj);
@@ -85,7 +86,7 @@ int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 		return 0;
 #endif
 	} else {
-		elog(LOG, "Error PLC inspection mode, unacceptable inpsection type %d", type);
+		plc_elog(LOG, "Error PLC inspection mode, unacceptable inpsection type %d", type);
 		return -1;
 	}
 

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -11,6 +11,7 @@
 #include "libpq/libpq.h"
 #include "miscadmin.h"
 #include "libpq/libpq-be.h"
+#include "common/comm_utils.h"
 #include "plc_docker_api_common.h"
 #include "cdb/cdbvars.h"
 
@@ -175,9 +176,9 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 			         (len > 0) ? errbuf : curl_easy_strerror(res));
 			buffer->status = -2;
 
-			elog(LOG, "Curl Request with type: %d, url: %s", cType, fullurl);
-			elog(LOG, "Curl Request with http body: %s\n", body);
-			elog(LOG, "Curl Request costs "
+			plc_elog(LOG, "Curl Request with type: %d, url: %s", cType, fullurl);
+			plc_elog(LOG, "Curl Request with http body: %s\n", body);
+			plc_elog(LOG, "Curl Request costs "
 				UINT64_FORMAT
 				"ms", elapsed_us / 1000);
 
@@ -187,7 +188,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 
 			curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &http_code);
 			buffer->status = (int) http_code;
-			elog(DEBUG1, "CURL response code is %ld. CURL response message is %s", http_code, buffer->data);
+			plc_elog(DEBUG1, "CURL response code is %ld. CURL response message is %s", http_code, buffer->data);
 		}
 
 		cleanup:
@@ -297,7 +298,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	if (res == 201) {
 		res = 0;
 	} else if (res >= 0) {
-		elog(LOG, "Docker fails to create container, response: %s", response->data);
+		plc_elog(LOG, "Docker fails to create container, response: %s", response->data);
 		snprintf(api_error_message, sizeof(api_error_message),
 		         "Failed to create container (return code: %d).", res);
 		res = -1;
@@ -309,7 +310,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	res = docker_inspect_string(response->data, name, PLC_INSPECT_NAME);
 
 	if (res < 0) {
-		elog(DEBUG1, "Error parsing container ID during creating container with errno %d.", res);
+		plc_elog(DEBUG1, "Error parsing container ID during creating container with errno %d.", res);
 		snprintf(api_error_message, sizeof(api_error_message),
 		         "Error parsing container ID during creating container");
 		goto cleanup;
@@ -337,7 +338,7 @@ int plc_docker_start_container(const char *name) {
 	if (res == 204 || res == 304) {
 		res = 0;
 	} else if (res >= 0) {
-		elog(DEBUG1, "start docker container %s failed with errno %d.", name, res);
+		plc_elog(DEBUG1, "start docker container %s failed with errno %d.", name, res);
 		snprintf(api_error_message, sizeof(api_error_message),
 		         "Failed to start container %s (return code: %d)", name, res);
 		res = -1;
@@ -352,7 +353,7 @@ int plc_docker_kill_container(const char *name) {
 	char *url = NULL;
 	int res = 0;
 
-	elog(FATAL, "Not finished yet. Do not call it.");
+	plc_elog(FATAL, "Not finished yet. Do not call it.");
 
 	url = palloc(strlen(method) + strlen(name) + 2);
 	sprintf(url, method, name);
@@ -385,7 +386,7 @@ int plc_docker_inspect_container(const char *name, char **element, plcInspection
 	}
 
 	if (res != 200) {
-		elog(LOG, "Docker cannot inspect container, response: %s", response->data);
+		plc_elog(LOG, "Docker cannot inspect container, response: %s", response->data);
 		snprintf(api_error_message, sizeof(api_error_message),
 		         "Docker inspect api returns http code %d on container %s", res, name);
 		res = -1;
@@ -411,7 +412,7 @@ int plc_docker_wait_container(const char *name) {
 	char *url = NULL;
 	int res = 0;
 
-	elog(FATAL, "Not finished yet. Do not call it.");
+	plc_elog(FATAL, "Not finished yet. Do not call it.");
 
 	url = palloc(strlen(method) + strlen(name) + 2);
 	sprintf(url, method, name);

--- a/src/plc_typeio.c
+++ b/src/plc_typeio.c
@@ -92,7 +92,7 @@ fill_type_info_inner(FunctionCallInfo fcinfo, Oid typeOid, plcTypeInfo *type, bo
 
 	typeTup = SearchSysCache(TYPEOID, typeOid, 0, 0, 0);
 	if (!HeapTupleIsValid(typeTup))
-		elog(ERROR, "cache lookup failed for type %u", typeOid);
+		plc_elog(ERROR, "cache lookup failed for type %u", typeOid);
 
 	typeStruct = (Form_pg_type) GETSTRUCT(typeTup);
 	ReleaseSysCache(typeTup);
@@ -232,7 +232,7 @@ fill_type_info_inner(FunctionCallInfo fcinfo, Oid typeOid, plcTypeInfo *type, bo
 				type->typ_relid = typeidTypeRelid(desc->tdtypeid);
 				relTup = SearchSysCache1(RELOID, ObjectIdGetDatum(type->typ_relid));
 				if (!HeapTupleIsValid(relTup)) {
-					elog(ERROR, "cache lookup failed for relation %u", type->typ_relid);
+					plc_elog(ERROR, "cache lookup failed for relation %u", type->typ_relid);
 				}
 
 				/* Extract the XMIN value to later use it in PLy_procedure_valid */

--- a/src/pyclient/client.c
+++ b/src/pyclient/client.c
@@ -46,7 +46,7 @@ int main(int argc UNUSED, char **argv UNUSED) {
 	setenv("CLIENT_LANGUAGE", "pythonclient", 0);
 
 	sock = start_listener();
-	lprintf(LOG, "Client has started execution at %s", asctime(timeinfo));
+	plc_elog(LOG, "Client has started execution at %s", asctime(timeinfo));
 
 	// Initialize Python
 	status = python_init();
@@ -59,6 +59,6 @@ int main(int argc UNUSED, char **argv UNUSED) {
 		plc_raise_delayed_error();
 	}
 
-	lprintf(LOG, "Client has finished execution");
+	plc_elog(LOG, "Client has finished execution");
 	return 0;
 }

--- a/src/pyclient/plpy_spi.c
+++ b/src/pyclient/plpy_spi.c
@@ -438,7 +438,7 @@ PLy_spi_execute_plan(PyObject *ob, PyObject *list, long limit) {
 	 * so if resp->cols > 0, it must be SELECT statment.
 	 */
 	if (resp->cols == 0) {
-		lprintf(DEBUG1, "the rows is %d", resp->rows);
+		plc_elog(DEBUG1, "the rows is %d", resp->rows);
 		PyObject *nrows = PyInt_FromLong((long) resp->rows);
 		/* only need one element for number of rows are processed*/
 		pyresult = PyList_New(1);
@@ -562,7 +562,7 @@ PLy_subtransaction_dealloc(PyObject *subxact UNUSED) {
 static PyObject *
 PLy_subtransaction_enter(PyObject *self, PyObject *unused UNUSED) {
 
-	lprintf(DEBUG1, "Subtransaction enter");
+	plc_elog(DEBUG1, "Subtransaction enter");
 	plcConn *conn = plcconn_global;
 	PLySubtransactionObject *subxact = (PLySubtransactionObject *) self;
 
@@ -628,7 +628,7 @@ PLy_subtransaction_enter(PyObject *self, PyObject *unused UNUSED) {
  */
 static PyObject *
 PLy_subtransaction_exit(PyObject *self, PyObject *args) {
-	lprintf(DEBUG1, "Subtransaction exit");
+	plc_elog(DEBUG1, "Subtransaction exit");
 	plcConn *conn = plcconn_global;
 	PyObject *type;
 	PyObject *value;
@@ -718,7 +718,7 @@ PLy_spi_execute_query(char *query, long limit) {
 	 * so if resp->cols > 0, it must be SELECT statment.
 	 */
 	if (resp->cols == 0) {
-		lprintf(DEBUG1, "the rows is %d", resp->rows);
+		plc_elog(DEBUG1, "the rows is %d", resp->rows);
 		PyObject *nrows = PyInt_FromLong((long) resp->rows);
 		/* only need one element for number of rows are processed*/
 		pyresult = PyList_New(1);
@@ -935,7 +935,7 @@ PLy_exception_set(PyObject *exc, const char *fmt, ...) {
 	vsnprintf(buf, sizeof(buf), dgettext(TEXTDOMAIN, fmt), ap);
 	va_end(ap);
 
-	lprintf(DEBUG1, "Python caught an exception: %s", buf);
+	plc_elog(DEBUG1, "Python caught an exception: %s", buf);
 
 	PyErr_SetString(exc, buf);
 }

--- a/src/pyclient/pycall.c
+++ b/src/pyclient/pycall.c
@@ -88,9 +88,9 @@ int python_init() {
 	 * initialize plpy module
 	 */
 	if (PyType_Ready(&PLy_PlanType) < 0)
-			lprintf (ERROR, "could not initialize PLy_PlanType");
+			plc_elog (ERROR, "could not initialize PLy_PlanType");
 	if (PyType_Ready(&PLy_SubtransactionType) < 0)
-			lprintf (ERROR, "could not initialize PLy_SubtransactionType");
+			plc_elog (ERROR, "could not initialize PLy_SubtransactionType");
 
 	/* create the plpy module */
 #if PY_MAJOR_VERSION >= 3

--- a/src/pyclient/pyerror.c
+++ b/src/pyclient/pyerror.c
@@ -110,7 +110,7 @@ void raise_execution_error(const char *format, ...) {
 		if (res < 0 || res >= len) {
 			msg = strdup("Error formatting error message string in raise_execution_error()");
 		}
-			lprintf(WARNING, "Python client caught an error: %s", msg);
+			plc_elog(WARNING, "Python client caught an error: %s", msg);
 	}
 	stack = get_python_error();
 
@@ -127,8 +127,8 @@ void raise_execution_error(const char *format, ...) {
 		plcLastErrMessage = err;
 		plc_raise_delayed_error();
 	} else {
-			lprintf(WARNING, "Cannot send second subsequent error message to client:");
-			lprintf(WARNING, msg);
+			plc_elog(WARNING, "Cannot send second subsequent error message to client:");
+			plc_elog(WARNING, msg);
 		free(msg);
 		if (stack != NULL) {
 			free(stack);

--- a/src/subtransaction_handler.c
+++ b/src/subtransaction_handler.c
@@ -33,7 +33,7 @@ static int16 plcontainer_subtransaction_exit(plcMsgSubtransaction *msg);
  */
 static int16
 plcontainer_subtransaction_enter() {
-	elog(DEBUG1, "subtransaction enter beigin");
+	plc_elog(DEBUG1, "subtransaction enter beigin");
 	PLySubtransactionData* volatile subxactdata = NULL;
 	MemoryContext oldcontext;
 	oldcontext = CurrentMemoryContext;
@@ -63,7 +63,7 @@ plcontainer_subtransaction_enter() {
 	MemoryContextSwitchTo(oldcontext);
 
 	explicit_subtransactions = lcons(subxactdata, explicit_subtransactions);
-	elog(DEBUG1, "subtransaction enter end, current explicit transaction num:%d",
+	plc_elog(DEBUG1, "subtransaction enter end, current explicit transaction num:%d",
 	     list_length(explicit_subtransactions));
 	return SUCCESS;
 }
@@ -74,7 +74,7 @@ plcontainer_subtransaction_enter() {
  *  When exit with exception, we need to rollback.
  */
 static int16 plcontainer_subtransaction_exit(plcMsgSubtransaction *msg) {
-	elog(DEBUG1, "subtransaction exit begin");
+	plc_elog(DEBUG1, "subtransaction exit begin");
 	PLySubtransactionData *subxactdata;
 	if (explicit_subtransactions == NIL) {
 		return NO_SUBTRANSACTION_ERROR;
@@ -106,7 +106,7 @@ static int16 plcontainer_subtransaction_exit(plcMsgSubtransaction *msg) {
 	 * case it did, make sure we remain connected.
 	 */
 	SPI_restore_connection();
-	elog(DEBUG1, "subtransaction exit end, current explicit transaction num: %d",
+	plc_elog(DEBUG1, "subtransaction exit end, current explicit transaction num: %d",
 	     list_length(explicit_subtransactions));
 	return SUCCESS;
 }
@@ -127,7 +127,7 @@ void plcontainer_process_subtransaction(plcMsgSubtransaction *msg, plcConn *conn
 
 	res = plcontainer_channel_send(conn, (plcMessage *) result);
 	if (res < 0) {
-		elog(ERROR, "Error sending data to the client, with errno %d. ", res);
+		plc_elog(ERROR, "Error sending data to the client, with errno %d. ", res);
 	}
 }
 
@@ -138,7 +138,7 @@ void plcontainer_process_subtransaction(plcMsgSubtransaction *msg, plcConn *conn
 void
 plcontainer_abort_open_subtransactions(int save_subxact_level) {
 	Assert(save_subxact_level >= 0);
-	elog(DEBUG1, "explicit_subtransactions length %d:%d", list_length(explicit_subtransactions), save_subxact_level);
+	plc_elog(DEBUG1, "explicit_subtransactions length %d:%d", list_length(explicit_subtransactions), save_subxact_level);
 	while (list_length(explicit_subtransactions) > save_subxact_level) {
 		PLySubtransactionData *subtransactiondata;
 

--- a/tests/expected/exception.out
+++ b/tests/expected/exception.out
@@ -1,6 +1,6 @@
 --  Test <defunct> processes are reaped after a new backend is created.
 select pykillself();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 SELECT pg_sleep(5);
  pg_sleep 
 ----------
@@ -21,7 +21,7 @@ select pyzero();
 0
 -- Test function ok immediately after container is kill-9-ed.
 select pykillself();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select pyzero();
  pyzero 
 --------
@@ -29,7 +29,7 @@ select pyzero();
 (1 row)
 
 select rkillself();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select rint(0);
  rint 
 ------
@@ -38,7 +38,7 @@ select rint(0);
 
 -- Test function ok immediately after container captures signal sigsegv.
 select pysegvself();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select pyzero();
  pyzero 
 --------
@@ -46,7 +46,7 @@ select pyzero();
 (1 row)
 
 select rsegvself();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select rint(0);
  rint 
 ------
@@ -55,7 +55,7 @@ select rint(0);
 
 -- Test function ok immediately after container exits.
 select pyexit();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select pyzero();
  pyzero 
 --------
@@ -63,7 +63,7 @@ select pyzero();
 (1 row)
 
 select rexit();
-ERROR:  Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:244)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select rint(0);
  rint 
 ------

--- a/tests/expected/spi_python.out
+++ b/tests/expected/spi_python.out
@@ -382,7 +382,7 @@ LINE 1: select datname from pg_database_invalid
                             ^
 QUERY:  select datname from pg_database_invalid
 select pyspi_bad_limit();
-ERROR:  Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (0) and limit (-2). Returns -6 (sqlhandler.c:330)
+ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (0) and limit (-2). Returns -6 (sqlhandler.c:330)
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
  py_spi_simple_t4 
@@ -398,9 +398,9 @@ DETAIL:
   File "<string>", line 4, in pyspi_bad_limit_pexecute
 TypeError: second argument of plpy.prepare must be a sequence
 select pyspi_bad_limit_immutable();
-ERROR:  Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Returns -6 (sqlhandler.c:330)
+ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Returns -6 (sqlhandler.c:330)
 select pyspi_bad_limit_stable();
-ERROR:  Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Returns -6 (sqlhandler.c:330)
+ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Returns -6 (sqlhandler.c:330)
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
  py_spi_simple_t4 

--- a/tests/expected/test_wrong_config.out
+++ b/tests/expected/test_wrong_config.out
@@ -4,35 +4,33 @@
 \! $(pwd)/test_wrong_config.sh 1
 Test lack of image
 select pylog100();
-ERROR:  Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:253)
+ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:257)
 \! $(pwd)/test_wrong_config.sh 2
 Test multiple image
 select pylog100();
-ERROR:  There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:250)
+ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:254)
 \! $(pwd)/test_wrong_config.sh 3
 Test multiple id
 select pylog100();
-ERROR:  tag <id> must be specified only once in configuartion (plc_configuration.c:114)
+ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_configuration.c:118)
 \! $(pwd)/test_wrong_config.sh 4
 Test lack of command element
 select pylog100();
-ERROR:  Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:260)
+ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:264)
 \! $(pwd)/test_wrong_config.sh 5
 Test log values should only be enable/disable
 select pylog100();
-ERROR:  SETTING element <log> only accepted "enable" or"disable" only, current string is yes (plc_configuration.c:190)
+ERROR:  plcontainer: SETTING element <log> only accepted "enable" or"disable" only, current string is yes (plc_configuration.c:194)
 \! $(pwd)/test_wrong_config.sh 6
 Test duplicate container path.
 select pylog100();
-ERROR:  Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:295)
+ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:298)
 \! $(pwd)/test_wrong_config.sh 7
 Test wrong use_network value.
 select pylog100();
-ERROR:  SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is enable (plc_configuration.c:218)
+ERROR:  plcontainer: SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is enable (plc_configuration.c:222)
 -- start_ignore
  \! plcontainer  runtime-restore -f /tmp/conf.bak
-20171226:23:26:20:008346 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
-20171226:23:26:20:008346 plcontainer:localhost:gpadmin-[INFO]:-Distributing to localhost.localdomain:/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/plcontainer_configuration.xml
-20171226:23:26:20:008346 plcontainer:localhost:gpadmin-[INFO]:-Distributing to localhost.localdomain:/home/gpadmin/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/plcontainer_configuration.xml
-20171226:23:26:20:008346 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically
+20180104:11:20:28:031148 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
+20180104:11:20:29:031148 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
 -- end_ignore


### PR DESCRIPTION
Use plc_elog() instead of elog() so that we could have seperate logging control than gpdb in the future.
Replace debug_print() with more meaningful function name channel_elog().
Replace all lprintf() with more meaning name plc_elog() also.