### PR TITLE
Refactor the backend api code a bit.

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -329,6 +329,10 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 
 	container_slot = find_container_slot();
 
+	/*
+	 * Hardcode as Docker at this moment. In the future the type should
+	 * be set in conf.
+	 */
 	enum PLC_BACKEND_TYPE plc_backend_type = BACKEND_DOCKER;
 	plc_backend_prepareImplementation(plc_backend_type);
 

--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -8,34 +8,34 @@
 #include "plc_backend_api.h"
 #include "common/comm_utils.h"
 
-static PLC_FunctionEntriesData CurrentPLCImp;
+static PLC_FunctionEntriesData *CurrentBackend;
 
 char api_error_message[256];
+
+static PLC_FunctionEntriesData DockerBackend =
+{
+	plc_docker_create_container,
+	plc_docker_start_container,
+	plc_docker_kill_container,
+	plc_docker_inspect_container,
+	plc_docker_wait_container,
+	plc_docker_delete_container,
+};
 
 /*
  * NOTE: Do not call plc_elog(>=ERROR, ...) in backend api code. Let the callers
  * handle according to the return value and error message string.
  */
 
-static void plc_docker_init(PLC_FunctionEntries entries) {
-	entries->create = plc_docker_create_container;
-	entries->start = plc_docker_start_container;
-	entries->kill = plc_docker_kill_container;
-	entries->inspect = plc_docker_inspect_container;
-	entries->wait = plc_docker_wait_container;
-	entries->delete_backend = plc_docker_delete_container;
-}
-
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
 	/*
 	 * Initialize plc backend implement handlers.
-	 * Currenty plcontainer only support BACKEND_DOCKER type,
-	 * it will support BACKEND_GARDEN, BACKEND_PROCESS in the future.
+	 * Currenty plcontainer only supports the BACKEND_DOCKER type.
+	 * Other possible backends include BACKEND_GARDEN, BACKEND_PROCESS, etc.
 	 */
-	memset(&CurrentPLCImp, 0, sizeof(PLC_FunctionEntriesData));
 	switch (imptype) {
 		case BACKEND_DOCKER:
-			plc_docker_init(&CurrentPLCImp);
+			CurrentBackend = &DockerBackend;
 			break;
 		default:
 			plc_elog(ERROR, "Unsupported plc backend type: %d", imptype);
@@ -43,25 +43,55 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
 }
 
 int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir) {
-	return CurrentPLCImp.create != NULL ? CurrentPLCImp.create(conf, name, container_slot, uds_dir) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->create_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend create");
+		return -1;
+	}
+
+	return CurrentBackend->create_backend(conf, name, container_slot, uds_dir);
 }
 
 int plc_backend_start(const char *name) {
-	return CurrentPLCImp.start != NULL ? CurrentPLCImp.start(name) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->start_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend start");
+		return -1;
+	}
+
+	return CurrentBackend->start_backend(name);
 }
 
 int plc_backend_kill(const char *name) {
-	return CurrentPLCImp.kill != NULL ? CurrentPLCImp.kill(name) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->kill_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend kill");
+		return -1;
+	}
+
+	return CurrentBackend->kill_backend(name);
 }
 
 int plc_backend_inspect(const char *name, char **element, plcInspectionMode type) {
-	return CurrentPLCImp.inspect != NULL ? CurrentPLCImp.inspect(name, element, type) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->inspect_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend inspect");
+		return -1;
+	}
+
+	return CurrentBackend->inspect_backend(name, element, type);
 }
 
 int plc_backend_wait(const char *name) {
-	return CurrentPLCImp.wait != NULL ? CurrentPLCImp.wait(name) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->wait_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend wait");
+		return -1;
+	}
+
+	return CurrentBackend->wait_backend(name);
 }
 
 int plc_backend_delete(const char *name) {
-	return CurrentPLCImp.delete_backend != NULL ? CurrentPLCImp.delete_backend(name) : 0;
+	if (CurrentBackend == NULL || CurrentBackend->delete_backend == NULL) {
+		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend delete");
+		return -1;
+	}
+
+	return CurrentBackend->delete_backend(name);
 }

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -28,16 +28,15 @@ typedef int ( *PLC_FPTR_wait)(const char *name);
 typedef int ( *PLC_FPTR_delete)(const char *name);
 
 struct PLC_FunctionEntriesData {
-	PLC_FPTR_create create;
-	PLC_FPTR_start start;
-	PLC_FPTR_kill kill;
-	PLC_FPTR_inspect inspect;
-	PLC_FPTR_wait wait;
+	PLC_FPTR_create create_backend;
+	PLC_FPTR_start start_backend;
+	PLC_FPTR_kill kill_backend;
+	PLC_FPTR_inspect inspect_backend;
+	PLC_FPTR_wait wait_backend;
 	PLC_FPTR_delete delete_backend;
 };
 
 typedef struct PLC_FunctionEntriesData PLC_FunctionEntriesData;
-typedef struct PLC_FunctionEntriesData *PLC_FunctionEntries;
 
 enum PLC_BACKEND_TYPE {
 	BACKEND_DOCKER = 0,
@@ -48,7 +47,8 @@ enum PLC_BACKEND_TYPE {
 
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
-/* interface for plc backend*/
+/* interfaces for plc backend. */
+
 int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
 
 int plc_backend_start(const char *name);

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -410,7 +410,7 @@ int plc_docker_inspect_container(const char *name, char **element, plcInspection
 		goto cleanup;
 	}
 
-	cleanup:
+cleanup:
 	plcCurlBufferFree(response);
 	pfree(url);
 


### PR DESCRIPTION
1) Remove plc_docker_init(). This way has the risk that we forget to set one or more interfaces.
2) Disallow null backend interface. Again for previous implementation we had the concern same as that in 1).