### PR TITLE
Fix potential issues in test test_wrong_config

### DIFF
--- a/tests/expected/test_wrong_config.out
+++ b/tests/expected/test_wrong_config.out
@@ -3,82 +3,110 @@
 -- end_ignore
 \! $(pwd)/test_wrong_config.sh 0
 Test lack of id
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: tag <id> must be specified in configuartion (plc_configuration.c:131)
 \! $(pwd)/test_wrong_config.sh 1
 Test lack of image
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:251)
 \! $(pwd)/test_wrong_config.sh 2
 Test multiple image
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:248)
 \! $(pwd)/test_wrong_config.sh 3
 Test multiple id
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_configuration.c:118)
 \! $(pwd)/test_wrong_config.sh 4
 Test lack of command element
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:258)
 \! $(pwd)/test_wrong_config.sh 5
 Test log values should only be enable/disable
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: SETTING element <log> only accepted "enable" or"disable" only, current string is yes (plc_configuration.c:194)
 \! $(pwd)/test_wrong_config.sh 6
 Test duplicate container path.
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:292)
 \! $(pwd)/test_wrong_config.sh 7
 Test wrong use_network value.
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is enable (plc_configuration.c:222)
 \! $(pwd)/test_wrong_config.sh 8
 Test duplicate id
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_configuration.c:118)
 \! $(pwd)/test_wrong_config.sh 9
 Test logs/use_network disable
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is disable (plc_configuration.c:222)
 \! $(pwd)/test_wrong_config.sh 10
 Test wrong setting
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:229)
 \! $(pwd)/test_wrong_config.sh 11
 Test wrong memory_mb
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: container memory size could not less 0, current string is -100 (plc_configuration.c:204)
 \! $(pwd)/test_wrong_config.sh 12
 Test wrong element
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Unrecognized element 'images' inside of container specification (plc_configuration.c:242)
 \! $(pwd)/test_wrong_config.sh 13
 Test more than 1 command
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: There are more than one 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:255)
 \! $(pwd)/test_wrong_config.sh 14
 Test 'host' missing in shared_directory
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'host' that is not found: plc_python_shared (plc_configuration.c:277)
 \! $(pwd)/test_wrong_config.sh 15
 Test 'container' missing in shared_directory
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'container' that is not found: plc_python_shared (plc_configuration.c:284)
 \! $(pwd)/test_wrong_config.sh 16
 Test 'access' missing in shared_directory
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'access' that is not found: plc_python_shared (plc_configuration.c:300)
 \! $(pwd)/test_wrong_config.sh 17
 Test bad access in shared_directory
-select pylog100();
+select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: Directory access mode should be either 'ro' or 'rw', but passed value is 'rx': plc_python_shared (plc_configuration.c:306)
 \! $(pwd)/test_wrong_config.sh 18
 Test good format (but it still fails since the configuration is not legal)
-select pylog100();
-ERROR:  plcontainer: Backend create error: Failed to create container (return code: 404). (containers.c:356)
+select plcontainer_refresh_local_config(true);
+INFO:  plcontainer: Container 'plc_python_shared' configuration
+INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
+INFO:  plcontainer:     memory_mb = '512'
+INFO:  plcontainer:     use network = 'yes'
+INFO:  plcontainer:     enable log  = 'no'
+INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
+INFO:  plcontainer:         access = readwrite
+INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients2' to container '/clientdir2'
+INFO:  plcontainer:         access = readonly
+ plcontainer_refresh_local_config 
+----------------------------------
+ ok
+(1 row)
+
+select plcontainer_show_local_config();
+INFO:  plcontainer: Container 'plc_python_shared' configuration
+INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
+INFO:  plcontainer:     memory_mb = '512'
+INFO:  plcontainer:     use network = 'yes'
+INFO:  plcontainer:     enable log  = 'no'
+INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
+INFO:  plcontainer:         access = readwrite
+INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients2' to container '/clientdir2'
+INFO:  plcontainer:         access = readonly
+ plcontainer_show_local_config 
+-------------------------------
+ ok
+(1 row)
+
 -- start_ignore
  \! plcontainer  runtime-restore -f /tmp/test_backup_cfg_file_wrong_config
-20180111:11:27:37:025178 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
-20180111:11:27:37:025178 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
+20180111:14:11:50:013023 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
+20180111:14:11:50:013023 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
 -- end_ignore

--- a/tests/sql/test_wrong_config.sql
+++ b/tests/sql/test_wrong_config.sql
@@ -3,61 +3,63 @@
 -- end_ignore
 
 \! $(pwd)/test_wrong_config.sh 0
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 1
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 2
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 3
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 4
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 5
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 6
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 7
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 8
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 9
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 10
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 11
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 12
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 13
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 14
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 15
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 16
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 17
-select pylog100();
+select plcontainer_refresh_local_config(true);
 
 \! $(pwd)/test_wrong_config.sh 18
-select pylog100();
+select plcontainer_refresh_local_config(true);
+
+select plcontainer_show_local_config();
 
 -- start_ignore
  \! plcontainer  runtime-restore -f /tmp/test_backup_cfg_file_wrong_config


### PR DESCRIPTION
After modifying configuration file, the session should call refresh related
UDF to update configurations. The previous test case works since the test
xml files are illegal and thus in each sql call the xml file is reread
according to the code.

We now remove "select pylog100()" and replace with "select plcontainer_refresh_local_config(true)".
With this the xml file will be 100% reparsed.

This patch also add test case to test UDF plcontainer_show_local_config().