### PR TITLE
Rename two configuration settings to be more readable

### DIFF
--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -21,8 +21,8 @@ export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-python-images.tar.gz; \
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz; \
-plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s logs=enable; \
-plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s logs=enable; \
+plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes; \
+plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s use_container_logging=yes; \
 gpstop -arf ; \
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 psql -d postgres -f plcontainer_src/tests/perfsql/function_setup.sql; \

--- a/concourse/scripts/run_plcontainer_tests.sh
+++ b/concourse/scripts/run_plcontainer_tests.sh
@@ -20,9 +20,9 @@ export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1; \
 source /usr/local/greenplum-db-devel/greenplum_path.sh; \
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-python-images.tar.gz; \
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz; \
-plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s logs=enable; \
-plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s logs=enable; \
-plcontainer runtime-add -r plc_python_network -i pivotaldata/plcontainer_python_shared:devel -l python -s logs=enable -s use_network=yes; \
+plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes; \
+plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s use_container_logging=yes; \
+plcontainer runtime-add -r plc_python_network -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes -s use_container_network=yes; \
 gpstop -arf; \
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 pushd plcontainer_src/tests; \

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -521,15 +521,15 @@ def validate_xml(filename):
                     except ValueError:
                         logger.error("memory_mb should be a positive integer in runtime %s, but now: '%s'", runtime_id, memory_mb_str)
                         raise Exception("Validation failed")
-                elif 'use_network' in settings.attrib:
-                    use_network_str = settings.attrib['use_network'].lower()
-                    if use_network_str != 'yes' and use_network_str != 'no':
-                        logger.error("use_network should be 'yes' or 'no' in runtime %s, but now: '%s'", runtime_id, use_network_str)
+                elif 'use_container_network' in settings.attrib:
+                    use_container_network_str = settings.attrib['use_container_network'].lower()
+                    if use_container_network_str != 'yes' and use_container_network_str != 'no':
+                        logger.error("use_container_network should be 'yes' or 'no' in runtime %s, but now: '%s'", runtime_id, use_container_network_str)
                         raise Exception("Validation failed")
-                elif 'logs' in settings.attrib:
-                    logs_str = settings.attrib['logs'].lower()
-                    if logs_str != 'enable' and logs_str != 'disable':
-                        logger.error("logs should be 'enable' or 'disable' in runtime %s, but now: '%s'", runtime_id, logs_str)
+                elif 'use_container_logging' in settings.attrib:
+                    use_container_logging_str = settings.attrib['use_container_logging'].lower()
+                    if use_container_logging_str != 'yes' and use_container_logging_str != 'no':
+                        logger.error("'use_container_logging' should be 'yes' or 'no' in runtime %s, but now: '%s'", runtime_id, use_container_logging_str)
                         raise Exception("Validation failed")
                 else:
                     logger.error("Found illegal setting in runtime %s: %s", runtime_id, settings.attrib)
@@ -657,10 +657,10 @@ def runtime_show_xml(filename, r_id):
                 for settings in runtime.findall('setting'):
                     if 'memory_mb' in settings.attrib:
                         sys.stdout.write("  ---- Container Memory Limited: %s MB\n" % settings.attrib['memory_mb'])
-                    elif 'use_network' in settings.attrib:
-                        sys.stdout.write("  ---- Container Use Network For Communication: %s\n" % settings.attrib['use_network'])
-                    elif 'logs' in settings.attrib:
-                        sys.stdout.write("  ---- Container Client Logging: %s\n" % settings.attrib['logs'])
+                    elif 'use_container_network' in settings.attrib:
+                        sys.stdout.write("  ---- Use Container Network For Communication: %s\n" % settings.attrib['use_container_network'])
+                    elif 'use_container_logging' in settings.attrib:
+                        sys.stdout.write("  ---- Use Container Logging: %s\n" % settings.attrib['use_container_logging'])
                 sys.stdout.write("  Shared Directory: \n")
                 for share_folder in runtime.findall('shared_directory'):
                     sys.stdout.write("  ---- Shared Directory From HOST '%s' to Container '%s', access mode is '%s'\n" % (share_folder.attrib['host'], share_folder.attrib['container'], share_folder.attrib['access']))
@@ -684,7 +684,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "use_network" and strList[0] != "memory_mb" and strList[0] != "logs":
+        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 

--- a/management/config/plcontainer_configuration.xml
+++ b/management/config/plcontainer_configuration.xml
@@ -19,11 +19,11 @@
             6.1. "memory_mb" - container memory limit in MB. Optional. When not set,
                  container can utilize all the available OS memory
                  directory shared between host and container.
-            6.2. "use_network" - set to "yes" or "no" to specify whether use tcp or ipc
+            6.2. "use_container_network" - set to "yes" or "no" to specify whether use tcp or ipc
                  for communication between gpdb process and container process. Optional.
                  By default, we set "no".
-            6.3. "logs" - set to "enable" or "disable" for container logging (not for backend)
-                 By default, we set "disable".
+            6.3. "use_container_logging" - set to "yes" or "no" for container logging (not for backend)
+                 By default, we set "no".
         All the container images not manually defined in this file will not be
         available for use by endusers in PL/Container
     -->
@@ -47,8 +47,8 @@
         <command>/clientdir/pyclient.sh</command>
         <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/>
         <setting memory_mb="512"/>
-        <setting use_network="yes"/>
-        <setting logs="enable"/>
+        <setting use_container_network="yes"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 
     <runtime>
@@ -56,7 +56,7 @@
         <image>pivotaldata/plcontainer_r_without_clients:0.2</image>
         <command>/clientdir/rclient.sh</command>
         <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/>
-        <setting logs="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 
 </configuration>

--- a/src/common/comm_server.c
+++ b/src/common/comm_server.c
@@ -192,7 +192,7 @@ static int start_listener_ipc() {
 
 int start_listener() {
 	int sock;
-	char *network;
+	char *use_container_network;
 	char *env_str, *endptr;
 	long val;
 
@@ -228,20 +228,23 @@ int start_listener() {
 		clientLanguage = strdup(env_str);
 	}
 
-	network = getenv("USE_NETWORK");
-	if (network == NULL) {
-		network = "no";
-		plc_elog(WARNING, "USE_NETWORK is not set, use default value \"no\".");
+	use_container_network = getenv("USE_CONTAINER_NETWORK");
+	if (use_container_network == NULL) {
+		use_container_network = "false";
+		plc_elog(WARNING, "USE_CONTAINER_NETWORK is not set, use default value \"no\".");
 	}
 
-	if (strcasecmp("true", network) == 0 || strcasecmp("yes", network) == 0) {
+	if (strcasecmp("true", use_container_network) == 0) {
 		sock = start_listener_inet();
-	} else {
+	} else if (strcasecmp("false", use_container_network) == 0){
 		if (geteuid() != 0 || getuid() != 0) {
 			plc_elog(ERROR, "Must run as root and then downgrade to usual user.");
 			return -1;
 		}
 		sock = start_listener_ipc();
+	} else {
+		sock = -1;
+		plc_elog(ERROR, "USE_CONTAINER_NETWORK is set to wrong value '%s'", use_container_network);
 	}
 
 	return sock;

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -42,8 +42,8 @@ typedef struct runtimeConfEntry {
 	int memoryMb;
 	int nSharedDirs;
 	plcSharedDir *sharedDirs;
-	bool isNetworkConnection;
-	bool enable_log;
+	bool useContainerNetwork;
+	bool useContainerLogging;
 } runtimeConfEntry;
 
 /* entrypoint for all plcontainer procedures */

--- a/src/plc_docker_curl_api.c
+++ b/src/plc_docker_curl_api.c
@@ -221,7 +221,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 			"              \"DB_USER_NAME=%s\",\n"
 			"              \"DB_NAME=%s\",\n"
 			"              \"DB_QE_PID=%d\",\n"
-			"              \"USE_NETWORK=%s\"],\n"
+			"              \"USE_CONTAINER_NETWORK=%s\"],\n"
 			"    \"NetworkDisabled\": %s,\n"
 			"    \"Image\": \"%s\",\n"
 			"    \"HostConfig\": {\n"
@@ -275,8 +275,8 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	snprintf(messageBody,
 	         createStringSize,
 	         createRequest,
-	         conf->enable_log ? "true" : "false",
-	         conf->enable_log ? "true" : "false",
+	         conf->useContainerLogging ? "true" : "false",
+	         conf->useContainerLogging ? "true" : "false",
 	         conf->command,
 	         getuid(),
 	         getgid(),
@@ -285,12 +285,12 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	         username,
 	         dbname,
 	         MyProcPid,
-	         conf->isNetworkConnection ? "true" : "false",
-	         conf->isNetworkConnection ? "false" : "true",
+	         conf->useContainerNetwork ? "true" : "false",
+	         conf->useContainerNetwork ? "false" : "true",
 	         conf->image,
 	         volumeShare,
 	         ((long long) conf->memoryMb) * 1024 * 1024,
-	         conf->enable_log ? default_log_dirver : "none",
+	         conf->useContainerLogging ? default_log_dirver : "none",
 	         username,
 	         GpIdentity.dbid);
 

--- a/tests/expected/test_utility.out
+++ b/tests/expected/test_utility.out
@@ -130,7 +130,7 @@ PL/Container Runtime Configuration:
   Linked Docker Image: image2
   Runtime Setting(s): 
   ---- Container Memory Limited: 512 MB
-  ---- Container Use Network For Communication: yes
+  ---- Use Container Network For Communication: yes
   Shared Directory: 
   ---- Shared Directory From HOST 'GPHOME/bin/plcontainer_clients' to Container '/clientdir', access mode is 'ro'
   ---- Shared Directory From HOST '/host_dir2/shared1' to Container '/container_dir2/shared1', access mode is 'rw'
@@ -184,7 +184,7 @@ Test runtime-replace: add a new one
         <shared_directory access="rw" container="/container_dir3/shared1" host="/host_dir3/shared1"/>
         <shared_directory access="ro" container="/container_dir3/shared2" host="/host_dir3/shared2"/>
         <setting memory_mb="512"/>
-        <setting use_network="yes"/>
+        <setting use_container_network="yes"/>
     </runtime>
 </configuration>
 
@@ -200,7 +200,7 @@ Test runtime-replace: replace
         <command>/clientdir/rclient.sh</command>
         <shared_directory access="ro" container="/clientdir" host="GPHOME/bin/plcontainer_clients"/>
         <shared_directory access="rw" container="/container_dir3/shared3" host="/host_dir3/shared3"/>
-        <setting use_network="no"/>
+        <setting use_container_network="no"/>
     </runtime>
 </configuration>
 
@@ -316,16 +316,16 @@ Test xml validation: negative cases
 -Validation failed
 -Bad xml format. Please fix the file at first.
 
-**Test: <setting>: use_network should be yes or no
+**Test: <setting>: use_container_network should be yes or no
 -image image1:0.1 is not in the list of 'docker images'
--use_network should be 'yes' or 'no' in runtime plc_python, but now: 'y'
+-use_container_network should be 'yes' or 'no' in runtime plc_python, but now: 'y'
 -XML file does not conform XML specification or wrong settings.
 -Validation failed
 -Bad xml format. Please fix the file at first.
 
-**Test: <setting>: logs should be enable or disable
+**Test: <setting>: use_container_logging should be yes or no
 -image image1:0.1 is not in the list of 'docker images'
--logs should be 'enable' or 'disable' in runtime plc_python, but now: 'yes'
+-'use_container_logging' should be 'yes' or 'no' in runtime plc_python, but now: 'enable'
 -XML file does not conform XML specification or wrong settings.
 -Validation failed
 -Bad xml format. Please fix the file at first.

--- a/tests/expected/test_wrong_config.out
+++ b/tests/expected/test_wrong_config.out
@@ -8,11 +8,11 @@ ERROR:  plcontainer: tag <id> must be specified in configuartion (plc_configurat
 \! $(pwd)/test_wrong_config.sh 1
 Test lack of image
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:251)
+ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:249)
 \! $(pwd)/test_wrong_config.sh 2
 Test multiple image
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:248)
+ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:246)
 \! $(pwd)/test_wrong_config.sh 3
 Test multiple id
 select plcontainer_refresh_local_config(true);
@@ -20,19 +20,19 @@ ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_
 \! $(pwd)/test_wrong_config.sh 4
 Test lack of command element
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:258)
+ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:256)
 \! $(pwd)/test_wrong_config.sh 5
-Test log values should only be enable/disable
+Test use_container_logging values should only be yes/no
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <log> only accepted "enable" or"disable" only, current string is yes (plc_configuration.c:194)
+ERROR:  plcontainer: SETTING element <use_container_logging> only accepted "yes" or"no" only, current string is enable (plc_configuration.c:194)
 \! $(pwd)/test_wrong_config.sh 6
 Test duplicate container path.
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:292)
+ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:290)
 \! $(pwd)/test_wrong_config.sh 7
-Test wrong use_network value.
+Test wrong use_container_network value.
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is enable (plc_configuration.c:222)
+ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is enable (plc_configuration.c:220)
 \! $(pwd)/test_wrong_config.sh 8
 Test duplicate id
 select plcontainer_refresh_local_config(true);
@@ -40,11 +40,11 @@ ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_
 \! $(pwd)/test_wrong_config.sh 9
 Test logs/use_network disable
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <use_network> only accepted "yes"|"true" or"no"|"false" only, current string is disable (plc_configuration.c:222)
+ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is disable (plc_configuration.c:220)
 \! $(pwd)/test_wrong_config.sh 10
 Test wrong setting
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:229)
+ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:227)
 \! $(pwd)/test_wrong_config.sh 11
 Test wrong memory_mb
 select plcontainer_refresh_local_config(true);
@@ -52,35 +52,35 @@ ERROR:  plcontainer: container memory size could not less 0, current string is -
 \! $(pwd)/test_wrong_config.sh 12
 Test wrong element
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Unrecognized element 'images' inside of container specification (plc_configuration.c:242)
+ERROR:  plcontainer: Unrecognized element 'images' inside of container specification (plc_configuration.c:240)
 \! $(pwd)/test_wrong_config.sh 13
 Test more than 1 command
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: There are more than one 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:255)
+ERROR:  plcontainer: There are more than one 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:253)
 \! $(pwd)/test_wrong_config.sh 14
 Test 'host' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'host' that is not found: plc_python_shared (plc_configuration.c:277)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'host' that is not found: plc_python_shared (plc_configuration.c:275)
 \! $(pwd)/test_wrong_config.sh 15
 Test 'container' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'container' that is not found: plc_python_shared (plc_configuration.c:284)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'container' that is not found: plc_python_shared (plc_configuration.c:282)
 \! $(pwd)/test_wrong_config.sh 16
 Test 'access' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'access' that is not found: plc_python_shared (plc_configuration.c:300)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'access' that is not found: plc_python_shared (plc_configuration.c:298)
 \! $(pwd)/test_wrong_config.sh 17
 Test bad access in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Directory access mode should be either 'ro' or 'rw', but passed value is 'rx': plc_python_shared (plc_configuration.c:306)
+ERROR:  plcontainer: Directory access mode should be either 'ro' or 'rw', but passed value is 'rx': plc_python_shared (plc_configuration.c:304)
 \! $(pwd)/test_wrong_config.sh 18
 Test good format (but it still fails since the configuration is not legal)
 select plcontainer_refresh_local_config(true);
 INFO:  plcontainer: Container 'plc_python_shared' configuration
 INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
 INFO:  plcontainer:     memory_mb = '512'
-INFO:  plcontainer:     use network = 'yes'
-INFO:  plcontainer:     enable log  = 'no'
+INFO:  plcontainer:     use container network = 'yes'
+INFO:  plcontainer:     use container logging  = 'no'
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
 INFO:  plcontainer:         access = readwrite
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients2' to container '/clientdir2'
@@ -94,8 +94,8 @@ select plcontainer_show_local_config();
 INFO:  plcontainer: Container 'plc_python_shared' configuration
 INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
 INFO:  plcontainer:     memory_mb = '512'
-INFO:  plcontainer:     use network = 'yes'
-INFO:  plcontainer:     enable log  = 'no'
+INFO:  plcontainer:     use container network = 'yes'
+INFO:  plcontainer:     use container logging  = 'no'
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
 INFO:  plcontainer:         access = readwrite
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients2' to container '/clientdir2'
@@ -107,6 +107,6 @@ INFO:  plcontainer:         access = readonly
 
 -- start_ignore
  \! plcontainer  runtime-restore -f /tmp/test_backup_cfg_file_wrong_config
-20180111:14:11:50:013023 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
-20180111:14:11:50:013023 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
+20180111:03:23:51:025813 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
+20180111:03:23:52:025813 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
 -- end_ignore

--- a/tests/test_utility.sh
+++ b/tests/test_utility.sh
@@ -94,7 +94,7 @@ plcontainer runtime-add -r runtime1 -i image1 -l python -v /host_dir1/shared1:/c
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-add -r runtime2 -i image2 -l r -v /host_dir2/shared1:/container_dir2/shared1:rw \
-		-v /host_dir2/shared2:/container_dir2/shared2:ro -s memory_mb=512 -s use_network=yes \
+		-v /host_dir2/shared2:/container_dir2/shared2:ro -s memory_mb=512 -s use_container_network=yes \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-show -r runtime_not_exist \
@@ -122,14 +122,14 @@ plcontainer runtime-replace -r runtime3 -i image3 -l r -s user_network=yes \
 echo
 echo "Test runtime-replace: add a new one"
 plcontainer runtime-replace -r runtime3 -i image2 -l r -v /host_dir3/shared1:/container_dir3/shared1:rw \
-	-v /host_dir3/shared2:/container_dir3/shared2:ro -s memory_mb=512 -s use_network=yes \
+	-v /host_dir3/shared2:/container_dir3/shared2:ro -s memory_mb=512 -s use_container_network=yes \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-backup -f /tmp/backup_file; cat /tmp/backup_file |  sed -e "s|${GPHOME}|GPHOME|"
 echo
 echo "Test runtime-replace: replace"
 plcontainer runtime-replace -r runtime3 -i image2 -l r -v /host_dir3/shared3:/container_dir3/shared3:rw \
-	-s use_network=no \
+	-s use_container_network=no \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-backup -f /tmp/backup_file; cat /tmp/backup_file |  sed -e "s|${GPHOME}|GPHOME|"
@@ -389,7 +389,7 @@ plcontainer runtime-restore -f /tmp/bad_xml_file \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
 
 echo
-echo "**Test: <setting>: use_network should be yes or no"
+echo "**Test: <setting>: use_container_network should be yes or no"
 cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
 <configuration>
@@ -397,7 +397,7 @@ cat >/tmp/bad_xml_file << EOF
         <id>plc_python</id>
         <image>image1:0.1</image>
         <command>./client</command>
-        <setting use_network="y"/>
+        <setting use_container_network="y"/>
     </runtime>
 </configuration>
 EOF
@@ -405,7 +405,7 @@ plcontainer runtime-restore -f /tmp/bad_xml_file \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
 
 echo
-echo "**Test: <setting>: logs should be enable or disable"
+echo "**Test: <setting>: use_container_logging should be yes or no"
 cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
 <configuration>
@@ -413,7 +413,7 @@ cat >/tmp/bad_xml_file << EOF
         <id>plc_python</id>
         <image>image1:0.1</image>
         <command>./client</command>
-        <setting logs="yes"/>
+        <setting use_container_logging="enable"/>
     </runtime>
 </configuration>
 EOF
@@ -430,8 +430,8 @@ cat >good_xml_file << EOF
         <id>plc_python</id>
         <image>image1:0.1</image>
         <setting memory_mb="512"/>
-        <setting use_network="NO"/>
-        <setting logs="Enable"/>
+        <setting use_container_network="NO"/>
+        <setting use_container_logging="Yes"/>
         <command>./client</command>
         <shared_directory access="rw" container="/clientdir" host="/host/plcontainer_clients"/>
     </runtime>

--- a/tests/test_wrong_config.sh
+++ b/tests/test_wrong_config.sh
@@ -45,7 +45,7 @@ f2 () {
         <image>pivotaldata/plcontainer_python:0.1</image>
         <command>./client</command>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/> 
-        <setting logs="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 </configuration>
 EOF
@@ -62,7 +62,7 @@ f3 () {
         <image>pivotaldata/plcontainer_python:0.1</image>
         <command>./client</command>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
-        <setting logs="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 </configuration>
 EOF
@@ -77,14 +77,14 @@ f4 () {
         <id>plc_python_shared</id>
         <image>pivotaldata/plcontainer_python:0.0</image>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
-        <setting logs="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 </configuration>
 EOF
 }
 
 f5 () {
-  echo "Test log values should only be enable/disable"
+  echo "Test use_container_logging values should only be yes/no"
   cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
 <configuration>
@@ -93,7 +93,7 @@ f5 () {
         <image>pivotaldata/plcontainer_python:0.1</image>
         <command>./client</command>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
-        <setting logs="yes"/>
+        <setting use_container_logging="enable"/>
     </runtime>
 </configuration>
 EOF
@@ -110,14 +110,14 @@ f6 () {
         <command>./client</command>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients2"/>
-        <setting logs="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 </configuration>
 EOF
 }
 
 f7 () {
-  echo "Test wrong use_network value."
+  echo "Test wrong use_container_network value."
   cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
 <configuration>
@@ -126,8 +126,8 @@ f7 () {
         <image>pivotaldata/plcontainer_python:0.1</image>
         <command>./client</command>
         <shared_directory access="ro" container="/clientdir" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients"/>
-        <setting logs="enable"/>
-        <setting use_network="enable"/>
+        <setting use_container_network="enable"/>
+        <setting use_container_logging="yes"/>
     </runtime>
 </configuration>
 EOF
@@ -157,8 +157,8 @@ f9 () {
         <id>plc_python_shared</id>
         <image>pivotaldata/plcontainer_python:0.1</image>
         <command>./client</command>
-        <setting logs="disable"/>
-        <setting use_network="disable"/>
+        <setting use_container_logging="no"/>
+        <setting use_container_network="disable"/>
         <setting memory_mb="512"/>
     </runtime>
 </configuration>
@@ -295,8 +295,8 @@ f18 () {
         <command>./not_exist_client</command>
         <shared_directory access="rw" container="/clientdir1" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients1"/> 
         <shared_directory access="ro" container="/clientdir2" host="/home/gpadmin/gpdb.devel/bin/plcontainer_clients2"/> 
-        <setting logs="disable"/>
-        <setting use_network="yes"/>
+        <setting use_container_logging="no"/>
+        <setting use_container_network="yes"/>
         <setting memory_mb="512"/>
     </runtime>
 </configuration>


### PR DESCRIPTION
1. Change 'logs' to 'use_container_logging'
2. Change 'use_network' to 'use_container_network'
3. Unify to use 'yes/no" only for values.

Author: Paul Guo <paulguo@gmail.com>
Author: Haozhou Wang <hawang@pivotal.io>