### PR TITLE
Enforce to check if backend api code return value is not used.

### DIFF
--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -49,16 +49,16 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
 /* interfaces for plc backend. */
 
-int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
+int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir) __attribute__((warn_unused_result));
 
-int plc_backend_start(const char *name);
+int plc_backend_start(const char *name) __attribute__((warn_unused_result));
 
-int plc_backend_kill(const char *name);
+int plc_backend_kill(const char *name) __attribute__((warn_unused_result));
 
-int plc_backend_inspect(const char *name, char **element, plcInspectionMode type);
+int plc_backend_inspect(const char *name, char **element, plcInspectionMode type) __attribute__((warn_unused_result));
 
-int plc_backend_wait(const char *name);
+int plc_backend_wait(const char *name) __attribute__((warn_unused_result));
 
-int plc_backend_delete(const char *name);
+int plc_backend_delete(const char *name) __attribute__((warn_unused_result));
 
 #endif /* PLC_BACKEND_API_H */

--- a/src/plc_docker_api_common.h
+++ b/src/plc_docker_api_common.h
@@ -39,8 +39,8 @@ int plc_docker_wait_container(const char *name);
 
 int plc_docker_delete_container(const char *name);
 
-int plc_docker_list_container(char **result);
+int plc_docker_list_container(char **result) __attribute__((warn_unused_result));
 
-int plc_docker_get_container_state(const char *name, char **result);
+int plc_docker_get_container_state(const char *name, char **result) __attribute__((warn_unused_result));
 
 #endif /* PLC_DOCKER_API_H */


### PR DESCRIPTION
We should do that so that the code could exit earlier and report more precise error.
This is inspired by the fix in my patch below.

commit a38fd5ca751bd3daf71a3a7ab3d375ef05d142ee
Error messages are missing in some docker api code. (#279)