### PR TITLE
Combine plcontainer resource management with  gpdb resource group.

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -538,6 +538,11 @@ def validate_xml(filename):
                     if use_container_logging_str != 'yes' and use_container_logging_str != 'no':
                         logger.error("'use_container_logging' should be 'yes' or 'no' in runtime %s, but now: '%s'", runtime_id, use_container_logging_str)
                         raise Exception("Validation failed")
+                elif 'resource_group_name' in settings.attrib:
+                    resource_group_name_str = settings.attrib['resource_group_name']
+                    if(len(resource_group_name_str) == 0):
+                        logger.error("length of 'resource_group_name_str' should not be zero.")
+                        raise Exception("Validation failed")
                 else:
                     logger.error("Found illegal setting in runtime %s: %s", runtime_id, settings.attrib)
     except Exception, ex:
@@ -668,6 +673,8 @@ def runtime_show_xml(filename, r_id):
                         sys.stdout.write("  ---- Use Container Network For Communication: %s\n" % settings.attrib['use_container_network'])
                     elif 'use_container_logging' in settings.attrib:
                         sys.stdout.write("  ---- Use Container Logging: %s\n" % settings.attrib['use_container_logging'])
+                    elif 'resource_group_name' in settings.attrib:
+                        sys.stdout.write("  ---- Resource Group Name: %s\n" % settings.attrib['resource_group_name'])
                 sys.stdout.write("  Shared Directory: \n")
                 for share_folder in runtime.findall('shared_directory'):
                     sys.stdout.write("  ---- Shared Directory From HOST '%s' to Container '%s', access mode is '%s'\n" % (share_folder.attrib['host'], share_folder.attrib['container'], share_folder.attrib['access']))
@@ -691,7 +698,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging":
+        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging" and strList[0] != "resource_group_name":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -16,6 +16,7 @@
 #define PLC_PROPERTIES_FILE "plcontainer_configuration.xml"
 #define RUNTIME_ID_MAX_LENGTH 64
 #define MAX_EXPECTED_RUNTIME_NUM 32
+#define RES_GROUP_PATH_MAX_LENGTH 256
 
 typedef enum {
 	PLC_ACCESS_READONLY = 0,
@@ -43,6 +44,7 @@ typedef struct runtimeConfEntry {
 	char runtimeid[RUNTIME_ID_MAX_LENGTH];
 	char *image;
 	char *command;
+	Oid resgroupOid;
 	int memoryMb;
 	int nSharedDirs;
 	plcSharedDir *sharedDirs;


### PR DESCRIPTION
This PR reset the cgroup parent of containers from 'docker' to a cgroup node under gpdb.
All the memory used in plcontainer can be managed by gpdb resource group.