### PR TITLE
[WIP] Integrate with gpdb resource group  to manage plcontainer resource

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -538,6 +538,11 @@ def validate_xml(filename):
                     if use_container_logging_str != 'yes' and use_container_logging_str != 'no':
                         logger.error("'use_container_logging' should be 'yes' or 'no' in runtime %s, but now: '%s'", runtime_id, use_container_logging_str)
                         raise Exception("Validation failed")
+                elif 'resource_group_name' in settings.attrib:
+                    resource_group_name_str = settings.attrib['resource_group_name']
+                    if(len(resource_group_name_str) == 0):
+                        logger.error("length of 'resource_group_name_str' should not be zero.")
+                        raise Exception("Validation failed")
                 else:
                     logger.error("Found illegal setting in runtime %s: %s", runtime_id, settings.attrib)
     except Exception, ex:
@@ -668,6 +673,8 @@ def runtime_show_xml(filename, r_id):
                         sys.stdout.write("  ---- Use Container Network For Communication: %s\n" % settings.attrib['use_container_network'])
                     elif 'use_container_logging' in settings.attrib:
                         sys.stdout.write("  ---- Use Container Logging: %s\n" % settings.attrib['use_container_logging'])
+                    elif 'resource_group_name' in settings.attrib:
+                        sys.stdout.write("  ---- Resource Group Name: %s\n" % settings.attrib['resource_group_name'])
                 sys.stdout.write("  Shared Directory: \n")
                 for share_folder in runtime.findall('shared_directory'):
                     sys.stdout.write("  ---- Shared Directory From HOST '%s' to Container '%s', access mode is '%s'\n" % (share_folder.attrib['host'], share_folder.attrib['container'], share_folder.attrib['access']))
@@ -691,7 +698,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging":
+        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging" and strList[0] != "resource_group_name":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 

--- a/src/containers.c
+++ b/src/containers.c
@@ -37,12 +37,6 @@ typedef struct {
 	char *dockerid;
 	plcConn *conn;
 } container_t;
-
-typedef struct {
-	Oid groupid;
-	char dockerid[CONTAINER_ID_MAX_LENGTH];
-} resgroup_cleanup_hook_data;
-
 #define MAX_CONTAINER_NUMBER 10
 #define CLEANUP_SLEEP_SEC 2
 #define CLEANUP_CONTAINER_CONNECT_RETRY_TIMES 60
@@ -55,13 +49,6 @@ static void init_containers();
 
 static int check_runtime_id(const char *id);
 
-static bool ResGroupPLCompare(void *arg1, void *arg2);
-
-static bool ResGroupPLCleanup(void *arg);
-
-static bool ContainerMemoryUsageIsHigh(Oid groupid);
-
-static int memory_redzone_to_clean_up = 20;
 #ifndef CONTAINER_DEBUG
 
 static int qe_is_alive(char *dockerid) {
@@ -439,15 +426,6 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 	while (wait3(&wait_status, WNOHANG, NULL) > 0);
 #endif
 
-	/* Register container cleanup callhook*/
-	if(conf->resgroupOid != InvalidOid) {
-		resgroup_cleanup_hook_data *hookArg = NULL;
-		hookArg = (resgroup_cleanup_hook_data *)MemoryContextAlloc(TopMemoryContext, sizeof(resgroup_cleanup_hook_data));
-		hookArg->groupid = conf->resgroupOid;
-		strncpy(hookArg->dockerid, dockerid, sizeof(hookArg->dockerid));
-
-		RegisterResGroupMemoryHook(RES_GROUP_MEMORY_HOOK_CLEAN, ResGroupPLCleanup, (void *)hookArg, ResGroupPLCompare);
-	}	
 	/* Create a process to clean up the container after it finishes */
 	cleanup(dockerid, uds_fn);
 
@@ -655,60 +633,4 @@ static int check_runtime_id(const char *id) {
 		return -1;
 	}
 	return 0;
-}
-
-static bool ContainerMemoryUsageIsHigh(Oid groupId)
-{
-	int32 memory_usage;
-        int32 memory_expected;
-
-        Assert(LWLockHeldExclusiveByMe(ResGroupLock));
-
-        memory_usage = ResGroupOps_GetMemoryUsage(groupId);
-        memory_expected = ResGroup_GetMemoryExpected(groupId);
-	
-	return memory_usage > memory_expected * memory_redzone_to_clean_up / 100;
-}
-static bool
-ResGroupPLCleanup(void *arg)
-{
-	Oid groupId;
-	char dockerid[CONTAINER_ID_MAX_LENGTH];
-	int res;
-	int _loop_cnt = 0;
-	
-
-	resgroup_cleanup_hook_data *cleanupData = (resgroup_cleanup_hook_data *)arg;
-	groupId = cleanupData->groupid;
-
-	if(!ContainerMemoryUsageIsHigh(groupId))
-		return false;
-
-	strncpy(dockerid, cleanupData->dockerid, sizeof(dockerid));
-
-	while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
-		pg_usleep(2000 * 1000L);
-
-	if (res < 0) {
-		plc_elog(NOTICE, "Container delete error at transation end: %s", api_error_message);
-		return false;
-	}
-	pfree(arg);
-
-	return true;
-}
-
-static bool
-ResGroupPLCompare(void *arg1, void *arg2)
-{
-	resgroup_cleanup_hook_data *cleanupData1 = (resgroup_cleanup_hook_data *)arg1;
-	resgroup_cleanup_hook_data *cleanupData2 = (resgroup_cleanup_hook_data *)arg2;
-
-	if (cleanupData1->groupid != cleanupData2->groupid)
-		return false;
-
-	if (strcmp(cleanupData1->dockerid, cleanupData2->dockerid))
-		return false;
-
-	return true;
 }

--- a/src/containers.c
+++ b/src/containers.c
@@ -680,11 +680,11 @@ ResGroupPLCleanup(void *arg)
 
 	resgroup_cleanup_hook_data *cleanupData = (resgroup_cleanup_hook_data *)arg;
 	groupId = cleanupData->groupid;
-	strncpy(dockerid, cleanupData->dockerid, sizeof(dockerid));
-	pfree(arg);
 
 	if(!ContainerMemoryUsageIsHigh(groupId))
 		return false;
+
+	strncpy(dockerid, cleanupData->dockerid, sizeof(dockerid));
 
 	while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
 		pg_usleep(2000 * 1000L);
@@ -693,6 +693,7 @@ ResGroupPLCleanup(void *arg)
 		plc_elog(NOTICE, "Container delete error at transation end: %s", api_error_message);
 		return false;
 	}
+	pfree(arg);
 
 	return true;
 }

--- a/src/containers.h
+++ b/src/containers.h
@@ -14,7 +14,7 @@
 #include "plc_configuration.h"
 
 #define CONTAINER_CONNECT_TIMEOUT_MS 10000
-
+#define CONTAINER_ID_MAX_LENGTH 128
 /* given source code of the function, extract the container name */
 char *parse_container_meta(const char *source);
 

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -549,7 +549,6 @@ runtimeConfEntry *plc_get_runtime_configuration(char *runtime_id) {
 		}
 	}
 
-	//const char* rr = (const char*) runtime_id;
 	/* find the corresponding runtime config*/
 	entry = (runtimeConfEntry *) hash_search(rumtime_conf_table,  (const void *) runtime_id, HASH_FIND, NULL);
 

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -16,6 +16,7 @@
 #define PLC_PROPERTIES_FILE "plcontainer_configuration.xml"
 #define RUNTIME_ID_MAX_LENGTH 64
 #define MAX_EXPECTED_RUNTIME_NUM 32
+#define RES_GROUP_PATH_MAX_LENGTH 256
 
 typedef enum {
 	PLC_ACCESS_READONLY = 0,
@@ -43,6 +44,7 @@ typedef struct runtimeConfEntry {
 	char runtimeid[RUNTIME_ID_MAX_LENGTH];
 	char *image;
 	char *command;
+	Oid resgroupOid;
 	int memoryMb;
 	int nSharedDirs;
 	plcSharedDir *sharedDirs;


### PR DESCRIPTION
Plcontainer resource management policy:
1 create resource group plgroup WITH (Concurrency =0, CPU_RATE_LIMIT=20, MEMORY_LIMIT=20);
It will create a cgroup node(MountPoint/memory/gpdb/plgroup_oid) with memory.limit equals to 20% of total memory of gpdb memory pool.

2 bind plgroup in runtime configuration.
It will make container run under the cgroup node(MountPoint/memory/gpdb/plgroup_oid).
Normal runtime will run container under MountPoint/memory/docker.

Memory-intensive plcontainer query will be killed in two case:
1 it exceeds runtime memory limit.
2 memory usage of all the container in any host exceed the memory limit of MountPoint/memory/gpdb/plgroup_oid

No matter how many memory plcontainer queries use, it will not affect gpdb normal queries.



