### PR TITLE
Wait for several seconds to give client a chance to exit normally ins…

### DIFF
--- a/src/plc_backend_api.c
+++ b/src/plc_backend_api.c
@@ -11,7 +11,8 @@
 
 static PLC_FunctionEntriesData *CurrentBackend;
 
-char api_error_message[256];
+/* If backend api returns error, the string will include more details. */
+char backend_error_message[256];
 
 static PLC_FunctionEntriesData DockerBackend =
 {
@@ -45,7 +46,7 @@ void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype) {
 
 int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir) {
 	if (CurrentBackend == NULL || CurrentBackend->create_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend create");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend create");
 		return -1;
 	}
 
@@ -54,7 +55,7 @@ int plc_backend_create(runtimeConfEntry *conf, char **name, int container_slot, 
 
 int plc_backend_start(const char *name) {
 	if (CurrentBackend == NULL || CurrentBackend->start_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend start");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend start");
 		return -1;
 	}
 
@@ -63,7 +64,7 @@ int plc_backend_start(const char *name) {
 
 int plc_backend_kill(const char *name) {
 	if (CurrentBackend == NULL || CurrentBackend->kill_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend kill");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend kill");
 		return -1;
 	}
 
@@ -72,7 +73,7 @@ int plc_backend_kill(const char *name) {
 
 int plc_backend_inspect(const char *name, char **element, plcInspectionMode type) {
 	if (CurrentBackend == NULL || CurrentBackend->inspect_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend inspect");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend inspect");
 		return -1;
 	}
 
@@ -81,7 +82,7 @@ int plc_backend_inspect(const char *name, char **element, plcInspectionMode type
 
 int plc_backend_wait(const char *name) {
 	if (CurrentBackend == NULL || CurrentBackend->wait_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend wait");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend wait");
 		return -1;
 	}
 
@@ -90,7 +91,7 @@ int plc_backend_wait(const char *name) {
 
 int plc_backend_delete(const char *name) {
 	if (CurrentBackend == NULL || CurrentBackend->delete_backend == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message), "Fail to get interface for backend delete");
+		snprintf(backend_error_message, sizeof(backend_error_message), "Fail to get interface for backend delete");
 		return -1;
 	}
 

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -12,7 +12,7 @@
 
 #include "plc_configuration.h"
 
-extern char api_error_message[256];
+extern char backend_error_message[256];
 
 typedef int ( *PLC_FPTR_create)(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
 

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -554,7 +554,7 @@ char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_
 				sprintf(volumes[i], " %c\"%s:%s:rw\"", comma, conf->sharedDirs[i].host,
 				        conf->sharedDirs[i].container);
 			} else {
-				snprintf(api_error_message, sizeof(api_error_message),
+				snprintf(backend_error_message, sizeof(backend_error_message),
 				         "Cannot determine directory sharing mode: %d",
 				         conf->sharedDirs[i].mode);
 				*has_error = true;
@@ -582,7 +582,7 @@ char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_
 
 			/* Create the directory. */
 			if (mkdir(*uds_dir, S_IRWXU) < 0 && errno != EEXIST) {
-				snprintf(api_error_message, sizeof(api_error_message),
+				snprintf(backend_error_message, sizeof(backend_error_message),
 				         "Cannot create directory %s: %s",
 				         *uds_dir, strerror(errno));
 				*has_error = true;
@@ -639,7 +639,7 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 
 		res = plc_docker_list_container(&json_result);
 		if (res < 0) {
-			plc_elog(ERROR, "Docker container list error: %s", api_error_message);
+			plc_elog(ERROR, "Docker container list error: %s", backend_error_message);
 		}
 
 		/* no container running */
@@ -757,7 +757,7 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 
 			res = plc_docker_get_container_state(idStr, &containerState);
 			if (res < 0) {
-				plc_elog(ERROR, "Fail to get docker container state: %s", api_error_message);
+				plc_elog(ERROR, "Fail to get docker container state: %s", backend_error_message);
 			}
 
 			containerStateObj = json_tokener_parse(containerState);

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -151,7 +151,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 				curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
 				break;
 			default:
-				snprintf(api_error_message, sizeof(api_error_message),
+				snprintf(backend_error_message, sizeof(backend_error_message),
 				         "Unsupported call type for PL/Container Docker Curl API: %d", cType);
 				buffer->status = -1;
 				goto cleanup;
@@ -175,7 +175,7 @@ static plcCurlBuffer *plcCurlRESTAPICall(plcCurlCallType cType,
 				((uint64) end_time.tv_sec) * 1000000 + end_time.tv_usec -
 				((uint64) start_time.tv_sec) * 1000000 - start_time.tv_usec;
 
-			snprintf(api_error_message, sizeof(api_error_message),
+			snprintf(backend_error_message, sizeof(backend_error_message),
 			         "PL/Container libcurl returns code %d, error '%s'", res,
 			         (len > 0) ? errbuf : curl_easy_strerror(res));
 			buffer->status = -2;
@@ -200,7 +200,7 @@ cleanup:
 		curl_slist_free_all(headers);
 		curl_easy_cleanup(curl);
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to start a curl session for unknown reason");
 		buffer->status = -1;
 	}
@@ -264,7 +264,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	errno = 0;
 	pwd = getpwnam("nobody");
 	if (pwd == NULL) {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to get passwd info for user 'nobody': %d", errno);
 		return -1;
 	}
@@ -307,11 +307,11 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 		res = 0;
 	} else if (res >= 0) {
 		plc_elog(LOG, "Docker fails to create container, response: %s", response->data);
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to create container (return code: %d).", res);
 		res = -1;
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to create container (return code: %d).", res);
 	}
 
@@ -322,7 +322,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 
 	if (res < 0) {
 		plc_elog(DEBUG1, "Error parsing container ID during creating container with errno %d.", res);
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Error parsing container ID during creating container");
 		goto cleanup;
 	}
@@ -350,11 +350,11 @@ int plc_docker_start_container(const char *name) {
 		res = 0;
 	} else if (res >= 0) {
 		plc_elog(DEBUG1, "start docker container %s failed with errno %d.", name, res);
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to start container %s (return code: %d)", name, res);
 		res = -1;
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to start container %s (return code: %d)", name, res);
 	}
 
@@ -405,7 +405,7 @@ int plc_docker_inspect_container(const char *name, char **element, plcInspection
 
 	if (res != 200) {
 		plc_elog(LOG, "Docker cannot inspect container, response: %s", response->data);
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Docker inspect api returns http code %d on container %s", res, name);
 		res = -1;
 		goto cleanup;
@@ -413,7 +413,7 @@ int plc_docker_inspect_container(const char *name, char **element, plcInspection
 
 	res = docker_inspect_string(response->data, element, type);
 	if (res < 0) {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to inspect the container.");
 		goto cleanup;
 	}
@@ -463,11 +463,11 @@ int plc_docker_delete_container(const char *name) {
 	if (res == 204 || res == 404) {
 		res = 0;
 	} else if (res >= 0) {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to delete container %s (return code: %d)", name, res);
 		res = -1;
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to delete container %s (return code: %d)", name, res);
 	}
 
@@ -491,11 +491,11 @@ int plc_docker_list_container(char **result) {
 	if (res == 200) {
 		res = 0;
 	} else if (res >= 0) {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to list containers (return code: %d), dbid is %d", res, GpIdentity.dbid);
 		res = -1;
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to list containers (return code: %d), dbid is %d", res, GpIdentity.dbid);
 	}
 	*result = pstrdup(response->data);
@@ -519,11 +519,11 @@ int plc_docker_get_container_state(const char *name, char **result) {
 	if (res == 200) {
 		res = 0;
 	} else if (res >= 0) {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to get container %s state (return code: %d)", name, res);
 		res = -1;
 	} else {
-		snprintf(api_error_message, sizeof(api_error_message),
+		snprintf(backend_error_message, sizeof(backend_error_message),
 		         "Failed to get container %s state (return code: %d)", name, res);
 	}
 


### PR DESCRIPTION
…tead of being killed with SIGKILL.

This is needed when collecting code coverage report for client code.

Also rename api_error_message to backend_error_message which is more explicit.