### PR TITLE
Add cpu.share setting for runtime configuration

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -526,7 +526,7 @@ def validate_xml(filename):
                     except ValueError:
                         logger.error("memory_mb should be a positive integer in runtime %s, but now: '%s'", runtime_id, memory_mb_str)
                         raise Exception("Validation failed")
-                if 'cpu_share' in settings.attrib:
+                elif 'cpu_share' in settings.attrib:
                     cpu_share_str = settings.attrib['cpu_share']
                     try:
                         cpu_share = int(cpu_share_str)
@@ -674,7 +674,7 @@ def runtime_show_xml(filename, r_id):
                 for settings in runtime.findall('setting'):
                     if 'memory_mb' in settings.attrib:
                         sys.stdout.write("  ---- Container Memory Limited: %s MB\n" % settings.attrib['memory_mb'])
-                    if 'cpu_share' in settings.attrib:
+                    elif 'cpu_share' in settings.attrib:
                         sys.stdout.write("  ---- Container CPU share: %s\n" % settings.attrib['cpu_share'])
                     elif 'use_container_network' in settings.attrib:
                         sys.stdout.write("  ---- Use Container Network For Communication: %s\n" % settings.attrib['use_container_network'])

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -520,11 +520,21 @@ def validate_xml(filename):
                     memory_mb_str = settings.attrib['memory_mb']
                     try:
                         memory_mb = int(memory_mb_str)
-                        if memory_mb < 0:
+                        if memory_mb <= 0:
                             logger.error("memory_mb should > 0 in runtime %s, but now: '%s'", runtime_id, memory_mb_str)
                             raise Exception("Validation failed")
                     except ValueError:
                         logger.error("memory_mb should be a positive integer in runtime %s, but now: '%s'", runtime_id, memory_mb_str)
+                        raise Exception("Validation failed")
+                if 'cpu_share' in settings.attrib:
+                    cpu_share_str = settings.attrib['cpu_share']
+                    try:
+                        cpu_share = int(cpu_share_str)
+                        if cpu_share <= 0:
+                            logger.error("cpu_share should > 0 in runtime %s, but now: '%s'", runtime_id, cpu_share_str)
+                            raise Exception("Validation failed")
+                    except ValueError:
+                        logger.error("cpu_share should be a positive integer in runtime %s, but now: '%s'", runtime_id, cpu_share_str)
                         raise Exception("Validation failed")
                 elif 'use_container_network' in settings.attrib:
                     use_container_network_str = settings.attrib['use_container_network'].lower()
@@ -664,6 +674,8 @@ def runtime_show_xml(filename, r_id):
                 for settings in runtime.findall('setting'):
                     if 'memory_mb' in settings.attrib:
                         sys.stdout.write("  ---- Container Memory Limited: %s MB\n" % settings.attrib['memory_mb'])
+                    if 'cpu_share' in settings.attrib:
+                        sys.stdout.write("  ---- Container CPU share: %s\n" % settings.attrib['cpu_share'])
                     elif 'use_container_network' in settings.attrib:
                         sys.stdout.write("  ---- Use Container Network For Communication: %s\n" % settings.attrib['use_container_network'])
                     elif 'use_container_logging' in settings.attrib:
@@ -691,7 +703,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "use_container_logging":
+        if strList[0] != "use_container_network" and strList[0] != "memory_mb" and strList[0] != "cpu_share" and strList[0] != "use_container_logging":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 

--- a/management/config/plcontainer_configuration.xml
+++ b/management/config/plcontainer_configuration.xml
@@ -18,11 +18,14 @@
            use its default value.
             6.1. "memory_mb" - container memory limit in MB. Optional. When not set,
                  container can utilize all the available OS memory
-                 directory shared between host and container.
-            6.2. "use_container_network" - set to "yes" or "no" to specify whether use tcp or ipc
+		 directory shared between host and container.
+	    6.2. "cpu_share" - container CPU share value. Optional. CPU share is an integer
+		 value representing this container's relative CPU weight versus other containers.
+		 When not set, the default CPU share is 1024.
+            6.3. "use_container_network" - set to "yes" or "no" to specify whether use tcp or ipc
                  for communication between gpdb process and container process. Optional.
                  By default, we set "no".
-            6.3. "use_container_logging" - set to "yes" or "no" for container logging (not for backend)
+            6.4. "use_container_logging" - set to "yes" or "no" for container logging (not for backend)
                  By default, we set "no".
         All the container images not manually defined in this file will not be
         available for use by endusers in PL/Container
@@ -49,7 +52,8 @@
         <image>pivotaldata/plcontainer_python_without_clients:0.1</image>
         <command>/clientdir/pyclient.sh</command>
         <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/>
-        <setting memory_mb="512"/>
+	<setting memory_mb="512"/>
+	<setting cpu_share="1024"/>
         <setting use_container_network="yes"/>
         <setting use_container_logging="yes"/>
     </runtime>

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -411,7 +411,7 @@ static void print_runtime_configurations() {
 			plc_elog(INFO, "Container '%s' configuration", conf_entry->runtimeid);
 			plc_elog(INFO, "    image = '%s'", conf_entry->image);
 			plc_elog(INFO, "    memory_mb = '%d'", conf_entry->memoryMb);
-			plc_elog(INFO, "    cpuShare = '%d'", conf_entry->cpuShare);
+			plc_elog(INFO, "    cpu_share = '%d'", conf_entry->cpuShare);
 			plc_elog(INFO, "    use container network = '%s'", conf_entry->useContainerNetwork ? "yes" : "no");
 			plc_elog(INFO, "    use container logging  = '%s'", conf_entry->useContainerLogging ? "yes" : "no");
 			for (j = 0; j < conf_entry->nSharedDirs; j++) {

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -153,6 +153,7 @@ static void parse_runtime_configuration(xmlNode *node) {
 
 		/*runtime_id will be freed with conf_entry*/
 		conf_entry->memoryMb = 1024;
+		conf_entry->cpuShare = 1024;
 		conf_entry->useContainerLogging = false;
 		conf_entry->useContainerNetwork = false;
 
@@ -210,9 +211,21 @@ static void parse_runtime_configuration(xmlNode *node) {
 						validSetting = true;
 						long memorySize = pg_atoi((char *) value, sizeof(int), 0);
 						if (memorySize <= 0) {
-							plc_elog(ERROR, "container memory size could not less 0, current string is %s", value);
+							plc_elog(ERROR, "container memory size couldn't be equal or less than 0, current string is %s", value);
 						} else {
 							conf_entry->memoryMb = memorySize;
+						}
+						xmlFree((void *) value);
+						value = NULL;
+					}
+					value = xmlGetProp(cur_node, (const xmlChar *) "cpu_share");
+					if (value != NULL) {
+						validSetting = true;
+						long cpuShare = pg_atoi((char *) value, sizeof(int), 0);
+						if (cpuShare <= 0) {
+							plc_elog(ERROR, "container cpu share couldn't be equal or less than 0, current string is %s", value);
+						} else {
+							conf_entry->cpuShare = cpuShare;
 						}
 						xmlFree((void *) value);
 						value = NULL;
@@ -398,6 +411,7 @@ static void print_runtime_configurations() {
 			plc_elog(INFO, "Container '%s' configuration", conf_entry->runtimeid);
 			plc_elog(INFO, "    image = '%s'", conf_entry->image);
 			plc_elog(INFO, "    memory_mb = '%d'", conf_entry->memoryMb);
+			plc_elog(INFO, "    cpuShare = '%d'", conf_entry->cpuShare);
 			plc_elog(INFO, "    use container network = '%s'", conf_entry->useContainerNetwork ? "yes" : "no");
 			plc_elog(INFO, "    use container logging  = '%s'", conf_entry->useContainerLogging ? "yes" : "no");
 			for (j = 0; j < conf_entry->nSharedDirs; j++) {

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -44,6 +44,7 @@ typedef struct runtimeConfEntry {
 	char *image;
 	char *command;
 	int memoryMb;
+	int cpuShare;
 	int nSharedDirs;
 	plcSharedDir *sharedDirs;
 	bool useContainerNetwork;

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -229,6 +229,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 			"    \"HostConfig\": {\n"
 			"        \"Binds\": [%s],\n"
 			"        \"Memory\": %lld,\n"
+			"        \"CpuShares\": %lld, \n"
 			"        \"PublishAllPorts\": true,\n"
 			"        \"LogConfig\":{\"Type\": \"%s\"}\n"
 			"    },\n"
@@ -292,6 +293,7 @@ int plc_docker_create_container(runtimeConfEntry *conf, char **name, int contain
 	         conf->image,
 	         volumeShare,
 	         ((long long) conf->memoryMb) * 1024 * 1024,
+			 ((long long) conf->cpuShare),
 	         conf->useContainerLogging ? default_log_dirver : "none",
 	         username,
 	         GpIdentity.dbid);

--- a/tests/expected/test_utility.out
+++ b/tests/expected/test_utility.out
@@ -131,6 +131,7 @@ PL/Container Runtime Configuration:
   Linked Docker Image: image2
   Runtime Setting(s): 
   ---- Container Memory Limited: 512 MB
+  ---- Container CPU share: 1024
   ---- Use Container Network For Communication: yes
   Shared Directory: 
   ---- Shared Directory From HOST 'GPHOME/bin/plcontainer_clients' to Container '/clientdir', access mode is 'ro'
@@ -311,9 +312,23 @@ Test xml validation: negative cases
 -Validation failed
 -Bad xml format. Please fix the file at first.
 
+**Test: <setting>: cpu_share should be string with integer value
+-image image1:0.1 is not in the list of 'docker images'
+-cpu_share should be a positive integer in runtime plc_python, but now: '102.4'
+-XML file does not conform XML specification or wrong settings.
+-Validation failed
+-Bad xml format. Please fix the file at first.
+
 **Test: <setting>: memory_mb should be string with positive integer value
 -image image1:0.1 is not in the list of 'docker images'
 -memory_mb should > 0 in runtime plc_python, but now: '-123'
+-XML file does not conform XML specification or wrong settings.
+-Validation failed
+-Bad xml format. Please fix the file at first.
+
+**Test: <setting>: cpu_share should be string with positive integer value
+-image image1:0.1 is not in the list of 'docker images'
+-cpu_share should > 0 in runtime plc_python, but now: '-123'
 -XML file does not conform XML specification or wrong settings.
 -Validation failed
 -Bad xml format. Please fix the file at first.

--- a/tests/expected/test_wrong_config.out
+++ b/tests/expected/test_wrong_config.out
@@ -8,11 +8,11 @@ ERROR:  plcontainer: tag <id> must be specified in configuartion (plc_configurat
 \! $(pwd)/test_wrong_config.sh 1
 Test lack of image
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:258)
+ERROR:  plcontainer: Lack of 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:271)
 \! $(pwd)/test_wrong_config.sh 2
 Test multiple image
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:255)
+ERROR:  plcontainer: There are more than one 'image' subelement in a runtime element plc_python_shared (plc_configuration.c:268)
 \! $(pwd)/test_wrong_config.sh 3
 Test multiple id
 select plcontainer_refresh_local_config(true);
@@ -20,19 +20,19 @@ ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_
 \! $(pwd)/test_wrong_config.sh 4
 Test lack of command element
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:265)
+ERROR:  plcontainer: Lack of 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:278)
 \! $(pwd)/test_wrong_config.sh 5
 Test use_container_logging values should only be yes/no
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <use_container_logging> only accepted "yes" or"no" only, current string is enable (plc_configuration.c:203)
+ERROR:  plcontainer: SETTING element <use_container_logging> only accepted "yes" or"no" only, current string is enable (plc_configuration.c:204)
 \! $(pwd)/test_wrong_config.sh 6
 Test duplicate container path.
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:299)
+ERROR:  plcontainer: Container path cannot be the same in 'shared_directory' element in the runtime plc_python_shared (plc_configuration.c:312)
 \! $(pwd)/test_wrong_config.sh 7
 Test wrong use_container_network value.
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is enable (plc_configuration.c:229)
+ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is enable (plc_configuration.c:242)
 \! $(pwd)/test_wrong_config.sh 8
 Test duplicate id
 select plcontainer_refresh_local_config(true);
@@ -40,49 +40,58 @@ ERROR:  plcontainer: tag <id> must be specified only once in configuartion (plc_
 \! $(pwd)/test_wrong_config.sh 9
 Test logs/use_network disable
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is disable (plc_configuration.c:229)
+ERROR:  plcontainer: SETTING element <use_container_network> only accepts "yes" or"no"only, current string is disable (plc_configuration.c:242)
 \! $(pwd)/test_wrong_config.sh 10
 Test wrong setting
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:236)
+ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:249)
 \! $(pwd)/test_wrong_config.sh 11
 Test wrong memory_mb
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: container memory size could not less 0, current string is -100 (plc_configuration.c:213)
+ERROR:  plcontainer: container memory size couldn't be equal or less than 0, current string is -100 (plc_configuration.c:214)
 \! $(pwd)/test_wrong_config.sh 12
 Test wrong element
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Unrecognized element 'images' inside of container specification (plc_configuration.c:249)
+ERROR:  plcontainer: Unrecognized element 'images' inside of container specification (plc_configuration.c:262)
 \! $(pwd)/test_wrong_config.sh 13
 Test more than 1 command
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: There are more than one 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:262)
+ERROR:  plcontainer: There are more than one 'command' subelement in a runtime element plc_python_shared (plc_configuration.c:275)
 \! $(pwd)/test_wrong_config.sh 14
 Test 'host' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'host' that is not found: plc_python_shared (plc_configuration.c:284)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'host' that is not found: plc_python_shared (plc_configuration.c:297)
 \! $(pwd)/test_wrong_config.sh 15
 Test 'container' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'container' that is not found: plc_python_shared (plc_configuration.c:291)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'container' that is not found: plc_python_shared (plc_configuration.c:304)
 \! $(pwd)/test_wrong_config.sh 16
 Test 'access' missing in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'access' that is not found: plc_python_shared (plc_configuration.c:307)
+ERROR:  plcontainer: Configuration tag 'shared_directory' has a mandatory element 'access' that is not found: plc_python_shared (plc_configuration.c:320)
 \! $(pwd)/test_wrong_config.sh 17
 Test bad access in shared_directory
 select plcontainer_refresh_local_config(true);
-ERROR:  plcontainer: Directory access mode should be either 'ro' or 'rw', but passed value is 'rx': plc_python_shared (plc_configuration.c:313)
+ERROR:  plcontainer: Directory access mode should be either 'ro' or 'rw', but passed value is 'rx': plc_python_shared (plc_configuration.c:326)
 \! $(pwd)/test_wrong_config.sh 18
 Test long runtime id which exceeds the length limit
 select plcontainer_refresh_local_config(true);
 ERROR:  plcontainer: runtime id should not be longer than 63 bytes. (plc_configuration.c:141)
 \! $(pwd)/test_wrong_config.sh 19
+Test wrong cpu_share name
+select plcontainer_refresh_local_config(true);
+ERROR:  plcontainer: Unrecognized setting options, please check the configuration file: plc_python_shared (plc_configuration.c:249)
+\! $(pwd)/test_wrong_config.sh 20
+Test wrong cpu_share value
+select plcontainer_refresh_local_config(true);
+ERROR:  plcontainer: container cpu share couldn't be equal or less than 0, current string is -100 (plc_configuration.c:226)
+\! $(pwd)/test_wrong_config.sh 21
 Test good format (but it still fails since the configuration is not legal)
 select plcontainer_refresh_local_config(true);
 INFO:  plcontainer: Container 'plc_python_shared' configuration
 INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
 INFO:  plcontainer:     memory_mb = '512'
+INFO:  plcontainer:     cpuShare = '1024'
 INFO:  plcontainer:     use container network = 'yes'
 INFO:  plcontainer:     use container logging  = 'no'
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
@@ -98,6 +107,7 @@ select plcontainer_show_local_config();
 INFO:  plcontainer: Container 'plc_python_shared' configuration
 INFO:  plcontainer:     image = 'not_exist_pivotaldata/plcontainer_python:0.1'
 INFO:  plcontainer:     memory_mb = '512'
+INFO:  plcontainer:     cpuShare = '1024'
 INFO:  plcontainer:     use container network = 'yes'
 INFO:  plcontainer:     use container logging  = 'no'
 INFO:  plcontainer:     shared directory from host '/home/gpadmin/gpdb.devel/bin/plcontainer_clients1' to container '/clientdir1'
@@ -111,7 +121,7 @@ INFO:  plcontainer:         access = readonly
 
 -- start_ignore
  \! plcontainer  runtime-restore -f /tmp/test_backup_cfg_file_wrong_config
-20180212:14:18:38:020544 plcontainer:paul6:gpadmin-[WARNING]:-Encourage to set use_container_network as 'no' (default value) for performance purpose.
-20180212:14:18:39:020544 plcontainer:paul6:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
-20180212:14:18:39:020544 plcontainer:paul6:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
+20180226:04:30:27:369203 plcontainer:localhost:gpadmin-[WARNING]:-Encourage to set use_container_network as 'no' (default value) for performance purpose.
+20180226:04:30:27:369203 plcontainer:localhost:gpadmin-[INFO]:-Distributing file plcontainer_configuration.xml to all locations...
+20180226:04:30:27:369203 plcontainer:localhost:gpadmin-[INFO]:-Configuration has changed. Run "select * from plcontainer_refresh_config" in open sessions. New sessions will get new configuration automatically.
 -- end_ignore

--- a/tests/sql/test_wrong_config.sql
+++ b/tests/sql/test_wrong_config.sql
@@ -62,6 +62,12 @@ select plcontainer_refresh_local_config(true);
 \! $(pwd)/test_wrong_config.sh 19
 select plcontainer_refresh_local_config(true);
 
+\! $(pwd)/test_wrong_config.sh 20
+select plcontainer_refresh_local_config(true);
+
+\! $(pwd)/test_wrong_config.sh 21
+select plcontainer_refresh_local_config(true);
+
 select plcontainer_show_local_config();
 
 -- start_ignore

--- a/tests/test_utility.sh
+++ b/tests/test_utility.sh
@@ -94,7 +94,7 @@ plcontainer runtime-add -r runtime1 -i image1 -l python -v /host_dir1/shared1:/c
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-add -r runtime2 -i image2 -l r -v /host_dir2/shared1:/container_dir2/shared1:rw \
-		-v /host_dir2/shared2:/container_dir2/shared2:ro -s memory_mb=512 -s use_container_network=yes \
+		-v /host_dir2/shared2:/container_dir2/shared2:ro -s memory_mb=512 -s cpu_share=1024 -s use_container_network=yes \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://' \
 	| grep -v 'Distributing to'
 plcontainer runtime-show -r runtime_not_exist \
@@ -373,6 +373,22 @@ plcontainer runtime-restore -f /tmp/bad_xml_file \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
 
 echo
+echo "**Test: <setting>: cpu_share should be string with integer value"
+cat >/tmp/bad_xml_file << EOF
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python</id>
+        <image>image1:0.1</image>
+        <command>./client</command>
+        <setting cpu_share="102.4"/>
+    </runtime>
+</configuration>
+EOF
+plcontainer runtime-restore -f /tmp/bad_xml_file \
+	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
+
+echo
 echo "**Test: <setting>: memory_mb should be string with positive integer value"
 cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
@@ -387,6 +403,23 @@ cat >/tmp/bad_xml_file << EOF
 EOF
 plcontainer runtime-restore -f /tmp/bad_xml_file \
 	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
+
+echo
+echo "**Test: <setting>: cpu_share should be string with positive integer value"
+cat >/tmp/bad_xml_file << EOF
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+	<id>plc_python</id>
+	<image>image1:0.1</image>
+	<command>./client</command>
+	<setting cpu_share="-123"/>
+    </runtime>
+</configuration>
+EOF
+plcontainer runtime-restore -f /tmp/bad_xml_file \
+	| sed -e 's/.*ERROR]://' -e 's/.*INFO]://' -e 's/.*CRITICAL]://' -e 's/.*WARNING]://'
+
 
 echo
 echo "**Test: <setting>: use_container_network should be yes or no"
@@ -446,6 +479,7 @@ cat >good_xml_file << EOF
         <id>plc_python</id>
         <image>image1:0.1</image>
         <setting memory_mb="512"/>
+        <setting cpu_share="1024"/>
         <setting use_container_network="NO"/>
         <setting use_container_logging="Yes"/>
         <command>./client</command>

--- a/tests/test_wrong_config.sh
+++ b/tests/test_wrong_config.sh
@@ -301,6 +301,36 @@ EOF
 }
 
 f19 () {
+  echo "Test wrong cpu_share name"
+  cat >/tmp/bad_xml_file << EOF
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python:0.1</image>
+        <command>./client</command>
+        <setting cpu="100"/>
+    </runtime>
+</configuration>
+EOF
+}
+
+f20 () {
+  echo "Test wrong cpu_share value"
+  cat >/tmp/bad_xml_file << EOF
+<?xml version="1.0" ?>
+<configuration>
+    <runtime>
+        <id>plc_python_shared</id>
+        <image>pivotaldata/plcontainer_python:0.1</image>
+        <command>./client</command>
+        <setting cpu_share="-100"/>
+    </runtime>
+</configuration>
+EOF
+}
+
+f21 () {
   echo "Test good format (but it still fails since the configuration is not legal)"
   cat >/tmp/bad_xml_file << EOF
 <?xml version="1.0" ?>
@@ -314,11 +344,11 @@ f19 () {
         <setting use_container_logging="no"/>
         <setting use_container_network="yes"/>
         <setting memory_mb="512"/>
+        <setting cpu_share="1024"/>
     </runtime>
 </configuration>
 EOF
 }
-
 
 function _main() {
   local config_id="${1}"
@@ -362,6 +392,10 @@ function _main() {
 	  f18
   elif [ "$config_id" = "19" ]; then
 	  f19
+  elif [ "$config_id" = "19" ]; then
+	  f20
+  elif [ "$config_id" = "19" ]; then
+	  f21
   fi
 
   if [ -z "$MASTER_DATA_DIRECTORY" ]; then

--- a/tests/test_wrong_config.sh
+++ b/tests/test_wrong_config.sh
@@ -392,9 +392,9 @@ function _main() {
 	  f18
   elif [ "$config_id" = "19" ]; then
 	  f19
-  elif [ "$config_id" = "19" ]; then
+  elif [ "$config_id" = "20" ]; then
 	  f20
-  elif [ "$config_id" = "19" ]; then
+  elif [ "$config_id" = "21" ]; then
 	  f21
   fi
 


### PR DESCRIPTION
We want to make containers of different runtime types using different percentage of CPU. This could be done through tuning the cpu.share of cgroup node.
'docker create' command support using cpu.share property to tuning the cpu.share value of cgroup node for this container.  This PR follows this idea to support this feature.