### PR TITLE
Fix SearchSysCache does not use correctly

### DIFF
--- a/src/plc_typeio.c
+++ b/src/plc_typeio.c
@@ -89,7 +89,7 @@ fill_type_info_inner(FunctionCallInfo fcinfo, Oid typeOid, plcTypeInfo *type, bo
 	char dummy_delim;
 	Oid typioparam;
 
-	typeTup = SearchSysCache(TYPEOID, typeOid, 0, 0, 0);
+	typeTup = SearchSysCache(TYPEOID, ObjectIdGetDatum(typeOid), 0, 0, 0);
 	if (!HeapTupleIsValid(typeTup))
 		plc_elog(ERROR, "cache lookup failed for type %u", typeOid);
 


### PR DESCRIPTION
In plc_typeio.c, SearchSysCache() inputs is datum, but
the current input is Oid. This commit fix this bug.