### PR TITLE
Add Notification when container is OOM killed

### DIFF
--- a/concourse/scripts/run_plcontainer_perf.sh
+++ b/concourse/scripts/run_plcontainer_perf.sh
@@ -29,6 +29,7 @@ plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontai
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz; \
 plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes; \
 plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s use_container_logging=yes; \
+plcontainer runtime-add -r plc_python_shared_oom -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes -s memory_mb=100; \
 gpstop -arf ; \
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 psql -d postgres -f plcontainer_src/tests/perfsql/function_setup.sql; \

--- a/concourse/scripts/run_plcontainer_tests.sh
+++ b/concourse/scripts/run_plcontainer_tests.sh
@@ -28,6 +28,7 @@ plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontai
 plcontainer image-add -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer-r-images.tar.gz; \
 plcontainer runtime-add -r plc_python_shared -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes; \
 plcontainer runtime-add -r plc_r_shared -i pivotaldata/plcontainer_r_shared:devel -l r -s use_container_logging=yes; \
+plcontainer runtime-add -r plc_python_shared_oom -i pivotaldata/plcontainer_python_shared:devel -l python -s use_container_logging=yes -s memory_mb=100; \
 gpstop -arf; \
 psql -d postgres -f /usr/local/greenplum-db-devel/share/postgresql/plcontainer/plcontainer_install.sql; \
 pushd plcontainer_src/tests; \

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -26,6 +26,7 @@ typedef enum {
 	PLC_INSPECT_STATUS = 0,
 	PLC_INSPECT_PORT = 1,
 	PLC_INSPECT_NAME = 2,
+	PLC_INSPECT_OOM = 3,
 	PLC_INSPECT_PORT_UNKNOWN,
 } plcInspectionMode;
 

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -613,6 +613,20 @@ static int docker_inspect_string(char *buf, char **element, plcInspectionMode ty
 		*element = pstrdup(StatusStr);
 		return 0;
 #endif
+	} else if (type == PLC_INSPECT_OOM) {
+		struct json_object *StateObj = NULL;
+		if (!json_object_object_get_ex(response, "State", &StateObj)) {
+			plc_elog(WARNING, "failed to get json \"State\" field.");
+			return -1;
+		}
+		struct json_object *OOMKillObj = NULL;
+		if (!json_object_object_get_ex(StateObj, "OOMKilled", &OOMKillObj)) {
+			plc_elog(WARNING, "failed to get json \"OOMKilled\" field.");
+			return -1;
+		}
+		const char *OOMKillStr = json_object_get_string(OOMKillObj);
+		*element = pstrdup(OOMKillStr);
+		return 0;
 	} else {
 		plc_elog(LOG, "Error PLC inspection mode, unacceptable inpsection type %d", type);
 		return -1;

--- a/tests/expected/oom_test_prepare_pyhthon.out
+++ b/tests/expected/oom_test_prepare_pyhthon.out
@@ -1,0 +1,21 @@
+-- set test functions
+CREATE OR REPLACE FUNCTION py_memory_allocate_oom(num int) RETURNS void AS $$
+# container: plc_python_shared_oom
+allocate = 'a' * num * 1024 * 1024
+$$ LANGUAGE plcontainer;
+CREATE OR REPLACE FUNCTION py_memory_allocate_normal(num int) RETURNS void AS $$
+# container: plc_python_shared
+allocate = 'a' * num * 1024 * 1024
+$$ LANGUAGE plcontainer;
+DROP TABLE IF EXISTS OOM_TEST;
+NOTICE:  table "oom_test" does not exist, skipping
+CREATE TABLE OOM_TEST (num int, aux int) DISTRIBUTED RANDOMLY;
+INSERT INTO OOM_TEST VALUES (1,512);
+INSERT INTO OOM_TEST VALUES (2,512);
+INSERT INTO OOM_TEST VALUES (3,512);
+INSERT INTO OOM_TEST VALUES (4,512);
+INSERT INTO OOM_TEST VALUES (5,512);
+INSERT INTO OOM_TEST VALUES (6,512);
+INSERT INTO OOM_TEST VALUES (7,512);
+INSERT INTO OOM_TEST VALUES (8,512);
+INSERT INTO OOM_TEST VALUES (9,512);

--- a/tests/expected/oom_test_python_killed.out
+++ b/tests/expected/oom_test_python_killed.out
@@ -1,0 +1,64 @@
+-- Out of memory on QD
+select py_memory_allocate_oom(1);
+ py_memory_allocate_oom 
+------------------------
+ 
+(1 row)
+
+select py_memory_allocate_oom(512);
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
+select py_memory_allocate_oom(1);
+ py_memory_allocate_oom 
+------------------------
+ 
+(1 row)
+
+select py_memory_allocate_normal(512);
+ py_memory_allocate_normal 
+---------------------------
+ 
+(1 row)
+
+select py_memory_allocate_oom(512);
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
+select py_memory_allocate_normal(512);
+ py_memory_allocate_normal 
+---------------------------
+ 
+(1 row)
+
+-- Out of memory on QE
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg1 slice1 127.0.0.1:25433 pid=26450)
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg0 slice1 127.0.0.1:25432 pid=26449)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)  (seg1 slice1 127.0.0.1:25433 pid=26450) (plcontainer.c:255)
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg0 slice1 127.0.0.1:25432 pid=26449)
+WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg1 slice1 127.0.0.1:25433 pid=26450)
+ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)  (seg0 slice1 127.0.0.1:25432 pid=26449) (plcontainer.c:255)
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+

--- a/tests/expected/oom_test_python_killed_1.out
+++ b/tests/expected/oom_test_python_killed_1.out
@@ -1,0 +1,1 @@
+oom_test_python_killed.out

--- a/tests/expected/oom_test_python_normal.out
+++ b/tests/expected/oom_test_python_normal.out
@@ -1,0 +1,74 @@
+-- Parallel tests on QD
+select py_memory_allocate_oom(1);
+ py_memory_allocate_oom 
+------------------------
+ 
+(1 row)
+
+select py_memory_allocate_oom(1);
+ py_memory_allocate_oom 
+------------------------
+ 
+(1 row)
+
+select py_memory_allocate_oom(1);
+ py_memory_allocate_oom 
+------------------------
+ 
+(1 row)
+
+select py_memory_allocate_normal(512);
+ py_memory_allocate_normal 
+---------------------------
+ 
+(1 row)
+
+select py_memory_allocate_normal(512);
+ py_memory_allocate_normal 
+---------------------------
+ 
+(1 row)
+
+select py_memory_allocate_normal(512);
+ py_memory_allocate_normal 
+---------------------------
+ 
+(1 row)
+
+-- Parallel tests on QE
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+ count 
+-------
+     0
+(1 row)
+

--- a/tests/expected/oom_test_python_normal_1.out
+++ b/tests/expected/oom_test_python_normal_1.out
@@ -1,0 +1,1 @@
+oom_test_python_normal.out

--- a/tests/expected/oom_test_python_normal_2.out
+++ b/tests/expected/oom_test_python_normal_2.out
@@ -1,0 +1,1 @@
+oom_test_python_normal.out

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -24,6 +24,10 @@ test: test_wrong_config
 # PL/Container UDA test
 test: uda_python uda_r
 
+# Out of memory test
+test: oom_test_prepare_pyhthon
+test: oom_test_python_killed oom_test_python_killed_1 oom_test_python_normal oom_test_python_normal_1 oom_test_python_normal_2
+
 # Miscellaneous test
 test: misc
 

--- a/tests/sql/oom_test_prepare_pyhthon.sql
+++ b/tests/sql/oom_test_prepare_pyhthon.sql
@@ -1,0 +1,22 @@
+-- set test functions
+CREATE OR REPLACE FUNCTION py_memory_allocate_oom(num int) RETURNS void AS $$
+# container: plc_python_shared_oom
+allocate = 'a' * num * 1024 * 1024
+$$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION py_memory_allocate_normal(num int) RETURNS void AS $$
+# container: plc_python_shared
+allocate = 'a' * num * 1024 * 1024
+$$ LANGUAGE plcontainer;
+
+DROP TABLE IF EXISTS OOM_TEST;
+CREATE TABLE OOM_TEST (num int, aux int) DISTRIBUTED RANDOMLY;
+INSERT INTO OOM_TEST VALUES (1,512);
+INSERT INTO OOM_TEST VALUES (2,512);
+INSERT INTO OOM_TEST VALUES (3,512);
+INSERT INTO OOM_TEST VALUES (4,512);
+INSERT INTO OOM_TEST VALUES (5,512);
+INSERT INTO OOM_TEST VALUES (6,512);
+INSERT INTO OOM_TEST VALUES (7,512);
+INSERT INTO OOM_TEST VALUES (8,512);
+INSERT INTO OOM_TEST VALUES (9,512);

--- a/tests/sql/oom_test_python_killed.sql
+++ b/tests/sql/oom_test_python_killed.sql
@@ -1,0 +1,17 @@
+-- Out of memory on QD
+select py_memory_allocate_oom(1);
+select py_memory_allocate_oom(512);
+select py_memory_allocate_oom(1);
+
+select py_memory_allocate_normal(512);
+select py_memory_allocate_oom(512);
+select py_memory_allocate_normal(512);
+
+-- Out of memory on QE
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;

--- a/tests/sql/oom_test_python_killed_1.sql
+++ b/tests/sql/oom_test_python_killed_1.sql
@@ -1,0 +1,1 @@
+oom_test_python_killed.sql

--- a/tests/sql/oom_test_python_normal.sql
+++ b/tests/sql/oom_test_python_normal.sql
@@ -1,0 +1,17 @@
+-- Parallel tests on QD
+select py_memory_allocate_oom(1);
+select py_memory_allocate_oom(1);
+select py_memory_allocate_oom(1);
+
+select py_memory_allocate_normal(512);
+select py_memory_allocate_normal(512);
+select py_memory_allocate_normal(512);
+
+-- Parallel tests on QE
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;
+select count(py_memory_allocate_oom(num)) from OOM_TEST;
+select count(py_memory_allocate_normal(aux)) from OOM_TEST;

--- a/tests/sql/oom_test_python_normal_1.sql
+++ b/tests/sql/oom_test_python_normal_1.sql
@@ -1,0 +1,1 @@
+oom_test_python_normal.sql

--- a/tests/sql/oom_test_python_normal_2.sql
+++ b/tests/sql/oom_test_python_normal_2.sql
@@ -1,0 +1,1 @@
+oom_test_python_normal.sql


### PR DESCRIPTION
1. Send a warning message to user if a container is
   out of memory and killed by docker oom killer
2. If this case is caught by cleanup process, a log
   will be written
3. Add related test cases

Co-authored-by: Shaoqi Bai(baishaoqicoding@gmail.com)
Co-authored-by: Haozhou Wang(hawang@pivotal.io)