### PR TITLE
Fix unstable test in centos6

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -38,7 +38,7 @@ typedef struct {
 } container_t;
 
 #define MAX_CONTAINER_NUMBER 10
-#define CLEANUP_SLEEP_SEC 2
+#define CLEANUP_SLEEP_SEC 3
 #define CLEANUP_CONTAINER_CONNECT_RETRY_TIMES 60
 
 static volatile int containers_init = 0;
@@ -111,8 +111,8 @@ static int delete_backend_if_exited(char *dockerid) {
 				 * check if the process is QE or not
 				 */
 				if (getppid() == PostmasterPid) {
-					plc_elog(WARNING, "container has been killed due to out of memory, please check your"
-							 " configuration or resource group settings");
+					plc_elog(WARNING, "docker reports container has been terminated due to out of memory," 
+							 " it could be the program over memory limit or crashed");
 				} else {
 					write_log("plcontainer cleanup process: container %s has been killed by oomkiller", dockerid);
 				}

--- a/tests/expected/oom_test_python_killed.out
+++ b/tests/expected/oom_test_python_killed.out
@@ -6,7 +6,6 @@ select py_memory_allocate_oom(1);
 (1 row)
 
 select py_memory_allocate_oom(512);
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings
 ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select py_memory_allocate_oom(1);
  py_memory_allocate_oom 
@@ -21,7 +20,6 @@ select py_memory_allocate_normal(512);
 (1 row)
 
 select py_memory_allocate_oom(512);
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings
 ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)
 select py_memory_allocate_normal(512);
  py_memory_allocate_normal 
@@ -37,8 +35,6 @@ select count(py_memory_allocate_oom(num)) from OOM_TEST;
 (1 row)
 
 select count(py_memory_allocate_oom(aux)) from OOM_TEST;
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg1 slice1 127.0.0.1:25433 pid=26450)
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg0 slice1 127.0.0.1:25432 pid=26449)
 ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)  (seg1 slice1 127.0.0.1:25433 pid=26450) (plcontainer.c:255)
 select count(py_memory_allocate_oom(num)) from OOM_TEST;
  count 
@@ -53,8 +49,6 @@ select count(py_memory_allocate_normal(aux)) from OOM_TEST;
 (1 row)
 
 select count(py_memory_allocate_oom(aux)) from OOM_TEST;
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg0 slice1 127.0.0.1:25432 pid=26449)
-WARNING:  plcontainer: container has been killed due to out of memory, please check your configuration or resource group settings  (seg1 slice1 127.0.0.1:25433 pid=26450)
 ERROR:  plcontainer: Error receiving data from the client: -1. Maybe retry later. (plcontainer.c:255)  (seg0 slice1 127.0.0.1:25432 pid=26449) (plcontainer.c:255)
 select count(py_memory_allocate_normal(aux)) from OOM_TEST;
  count 

--- a/tests/init_file
+++ b/tests/init_file
@@ -5,6 +5,7 @@
 -- start_matchignore
 # match ignore docker api WARNING message
 m/^WARNING:  Docker API.*/
+m/^WARNING:  plcontainer: docker reports container*/
 
 # for drop extension
 m/^NOTICE:  drop cascades to \d+ other objects*/


### PR DESCRIPTION
1. Update warnning message to suit old docker version
2. Increase sleep time from 2 seconds to 3 seconds

Co-authored-by: Shaoqi Bai(baishaoqicoding@gmail.com)
Co-authored-by: Haozhou Wang(hawang@pivotal.io)