### PR TITLE
Increase sleep time in faultinject_python test

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -111,8 +111,8 @@ static int delete_backend_if_exited(char *dockerid) {
 				 * check if the process is QE or not
 				 */
 				if (getppid() == PostmasterPid) {
-					plc_elog(WARNING, "docker reports container has been terminated due to out of memory," 
-							 " it could be the program over memory limit or crashed");
+					plc_elog(WARNING, "docker reports container has been terminated due to out of memory." 
+							 " This could be either the container was over memory limit or inside program crashed");
 				} else {
 					write_log("plcontainer cleanup process: container %s has been killed by oomkiller", dockerid);
 				}

--- a/tests/expected/faultinject_python.out
+++ b/tests/expected/faultinject_python.out
@@ -63,7 +63,7 @@ NOTICE:  Success:
 
 SELECT pyint(i) from tbl;
 ERROR:  fault triggered, fault name:'plcontainer_before_container_started' fault type:'fatal'  (seg0 slice1 127.0.0.1:25432 pid=3066)
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -92,7 +92,7 @@ NOTICE:  Success:
 
 SELECT pyint(i) from tbl;
 ERROR:  fault triggered, fault name:'plcontainer_before_container_connected' fault type:'fatal'  (seg0 slice1 127.0.0.1:25432 pid=3254)
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -119,7 +119,7 @@ NOTICE:  Success:
 
 SELECT pyint(i) from tbl;
 ERROR:  fault triggered, fault name:'plcontainer_after_send_request' fault type:'fatal'  (seg0 slice1 127.0.0.1:25432 pid=3434)
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -146,7 +146,7 @@ NOTICE:  Success:
 
 SELECT pyint(i) from tbl;
 ERROR:  fault triggered, fault name:'plcontainer_after_recv_request' fault type:'fatal'  (seg0 slice1 127.0.0.1:25432 pid=3612)
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -173,7 +173,7 @@ NOTICE:  Success:
 
 SELECT pyint(i) from tbl;
 ERROR:  fault triggered, fault name:'plcontainer_before_udf_finish' fault type:'fatal'  (seg0 slice1 127.0.0.1:25432 pid=3797)
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -254,7 +254,7 @@ NOTICE:  Success:
 
 SELECT pyint(0);
 ERROR:  fault triggered, fault name:'plcontainer_before_container_started' fault type:'error'
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  
@@ -281,7 +281,7 @@ NOTICE:  Success:
 
 SELECT pyint(2);
 ERROR:  fault triggered, fault name:'plcontainer_after_send_request' fault type:'error'
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
  pg_sleep 
 ----------
  

--- a/tests/init_file
+++ b/tests/init_file
@@ -5,6 +5,7 @@
 -- start_matchignore
 # match ignore docker api WARNING message
 m/^WARNING:  Docker API.*/
+# ignore due to docker in centos 6 could not detect OOM accurately 
 m/^WARNING:  plcontainer: docker reports container*/
 
 # for drop extension

--- a/tests/sql/faultinject_python.sql
+++ b/tests/sql/faultinject_python.sql
@@ -24,7 +24,7 @@ SELECT gp_inject_fault('plcontainer_before_udf_finish', 'reset', 2);
 show optimizer;
 SELECT gp_inject_fault('plcontainer_before_container_started', 'fatal', 2);
 SELECT pyint(i) from tbl;
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! ssh `psql -d ${PL_TESTDB} -c 'select address from gp_segment_configuration where dbid=2' -t -A` docker ps -a </dev/null | wc -l
@@ -37,7 +37,7 @@ SELECT sum(pyint(i)) from tbl;
 -- QE crash when connnecting to an existing container
 SELECT gp_inject_fault('plcontainer_before_container_connected', 'fatal', 2);
 SELECT pyint(i) from tbl;
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! ssh `psql -d ${PL_TESTDB} -c 'select address from gp_segment_configuration where dbid=2' -t -A` docker ps -a </dev/null | wc -l
@@ -47,7 +47,7 @@ SELECT sum(pyint(i)) from tbl;
 -- start_ignore
 SELECT gp_inject_fault('plcontainer_after_send_request', 'fatal', 2);
 SELECT pyint(i) from tbl;
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! ssh `psql -d ${PL_TESTDB} -c 'select address from gp_segment_configuration where dbid=2' -t -A` docker ps -a </dev/null | wc -l
@@ -57,7 +57,7 @@ SELECT sum(pyint(i)) from tbl;
 -- start_ignore
 SELECT gp_inject_fault('plcontainer_after_recv_request', 'fatal', 2);
 SELECT pyint(i) from tbl;
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! ssh `psql -d ${PL_TESTDB} -c 'select address from gp_segment_configuration where dbid=2' -t -A` docker ps -a </dev/null | wc -l
@@ -67,7 +67,7 @@ SELECT sum(pyint(i)) from tbl;
 -- start_ignore
 SELECT gp_inject_fault('plcontainer_before_udf_finish', 'fatal', 2);
 SELECT pyint(i) from tbl;
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! ssh `psql -d ${PL_TESTDB} -c 'select address from gp_segment_configuration where dbid=2' -t -A` docker ps -a </dev/null | wc -l
@@ -92,7 +92,7 @@ SELECT gp_inject_fault('plcontainer_after_send_request', 'reset', 1);
 show optimizer;
 SELECT gp_inject_fault('plcontainer_before_container_started', 'error', 1);
 SELECT pyint(0);
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! docker ps -a </dev/null | wc -l
@@ -102,7 +102,7 @@ SELECT pyint(1);
 -- start_ignore
 SELECT gp_inject_fault('plcontainer_after_send_request', 'error', 1);
 SELECT pyint(2);
-SELECT pg_sleep(5);
+SELECT pg_sleep(10);
 -- end_ignore
 
 \! docker ps -a </dev/null | wc -l


### PR DESCRIPTION
1. The sleep time is increased from 5 seconds to
10 seconds in faultinject_python test to make
centos6 concourse pipelien more stable.

2. Adjust warning text when OOM