### PR TITLE
Fix release pipeline error in GCP

### DIFF
--- a/concourse/release-pipeline.yml
+++ b/concourse/release-pipeline.yml
@@ -356,7 +356,7 @@ jobs:
     params:
       <<: *ccp_default_params
       vars:
-        instance_type: n1-standard-1
+        instance_type: n1-standard-4
         PLATFORM: centos6
         disk_size: 100
         disk_type: pd-ssd
@@ -409,7 +409,7 @@ jobs:
     params:
       <<: *ccp_default_params
       vars:
-        instance_type: n1-standard-1
+        instance_type: n1-standard-4
         PLATFORM: centos7
         disk_size: 100
         disk_type: pd-ssd
@@ -528,8 +528,7 @@ jobs:
       plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
   - put: plcontainer_docker_image_centos_r
     params:
-     file: plcontainer_docker_image/plcontainer*.tar.gz
-      file: plcontainer_docker_image/plcontainer-r-images-devel.tar.gz
+      file: plcontainer_docker_image/plcontainer*.tar.gz
     on_success:
       <<: *ccp_destroy
   ensure:

--- a/concourse/scripts/build_plcontainer.sh
+++ b/concourse/scripts/build_plcontainer.sh
@@ -26,11 +26,11 @@ build_plcontainer() {
   # build plcontainer
   pushd plcontainer_src
   if [ "${DEV_RELEASE}" == "release" ]; then
-      if git describe >/dev/null 2>&1 ; then
+      if git describe --tags >/dev/null 2>&1 ; then
           echo "git describe failed" || exit 1
       fi
-      PLCONTAINER_VERSION=$(git describe | awk -F. '{printf("%d.%d", $1, $2)}')
-      PLCONTAINER_RELEASE=$(git describe | awk -F. '{print $3}')
+      PLCONTAINER_VERSION=$(git describe --tags | awk -F. '{printf("%d.%d", $1, $2)}')
+      PLCONTAINER_RELEASE=$(git describe --tags | awk -F. '{print $3}')
   else
       PLCONTAINER_VERSION="0.0"
       PLCONTAINER_RELEASE="0"


### PR DESCRIPTION
1. Fix image_build job in GCP concourse.
2. Change to `git describe --tags` to get correct tags

No need to test as this commit is related to concourse pipeline