### PR TITLE
Fix tag info error in docker build job

### DIFF
--- a/concourse/scripts/docker_build_image.sh
+++ b/concourse/scripts/docker_build_image.sh
@@ -14,7 +14,7 @@ pushd plcontainer_src
 if [ "$DEV_RELEASE" == "devel" ]; then
 	IMAGE_NAME="plcontainer-$language-images-devel.tar.gz"
 else
-	PLCONTAINER_VERSION=$(git describe)
+	PLCONTAINER_VERSION=$(git describe --tags)
 	IMAGE_NAME="plcontainer-$language-images-${PLCONTAINER_VERSION}.tar.gz"
 fi
 popd


### PR DESCRIPTION
```
git describe
```
may not get the correct tag info in GCP, using 
```
git describe --tags
```
instead. 

P.S. No test needed for this PR as it is targeting for concourse pipeline