### PR TITLE
test_python and test_r should not run at parallel

### DIFF
--- a/tests/pl_resgroup_schedule
+++ b/tests/pl_resgroup_schedule
@@ -5,7 +5,9 @@ test: schema
 test: function_r function_r_gpdb5 function_python function_python_gpdb5
 
 # test PL/Container normal function
-test: test_r test_python test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
+test: test_r 
+test: test_python
+test: test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
 test: test_r_error test_python_error 
 test: exception
 test: faultinject_python

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -14,7 +14,9 @@ test: runtimeid_declaration
 test: function_r function_r_gpdb5 function_python function_python_gpdb5
 
 # test PL/Container normal function
-test: test_r test_python test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
+test: test_r 
+test: test_python
+test: test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
 test: test_r_error test_python_error 
 test: exception
 test: faultinject_python


### PR DESCRIPTION

## Description
test_python and test_r should not run at parallel
since both test suites test the plpy.fatal.

## Tests
This is test schedule adjustment.

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
