### PR TITLE
Remove elog in cleanup process.

### DIFF
--- a/src/common/comm_utils.h
+++ b/src/common/comm_utils.h
@@ -122,6 +122,18 @@ int sanity_check_client(void);
 
 #include "postgres.h"
 
+/* QE process uses elog, while cleanup process should use write_log*/
+#define backend_log(elevel, ...)  \
+	do { \
+		if (getppid() == PostmasterPid) { \
+			plc_elog(elevel, __VA_ARGS__); \
+		} else { \
+			write_log(__VA_ARGS__); \
+		} \
+	} while(0)
+
+
+
 #define plc_elog(lvl, fmt, ...) elog(lvl, "plcontainer: " fmt, ##__VA_ARGS__);
 #define pmalloc palloc
 


### PR DESCRIPTION
## Description
palloc may be called inside elog, but QE process
and cleanup process share the same resource group
slot to do memory auditor. This slot maybe freed
after QE process exits, which cause elog of cleanup
process to corrupt. We need to use write_log to replace
elog in cleanup process.

## Tests
<!-- describe your test -->
The tests are already exists, make them green under resource group mode.
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
#359

Co-authored-by: Haozhou Wang <hawang@pivotal.io>
