### PR TITLE
Add datasciencebundle regression tests to plcontainer

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,7 +56,7 @@ tests:
 	fi
 	PL_TESTDB=$(PL_TESTDB) $(top_builddir)/src/test/regress/pg_regress \
 				--psqldir=$(PSQLDIR) $(REGRESS_OPTS) || if [[ -f regression.diffs ]]; then cat regression.diffs; exit 1; fi
-
+				
 .PHONY: submake
 submake:
 	$(MAKE) -C $(top_builddir)/src/test/regress pg_regress$(X)

--- a/tests/expected/python_import_module.out
+++ b/tests/expected/python_import_module.out
@@ -1,0 +1,314 @@
+--
+-- import numpy
+--
+create or replace function numpy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy
+a = numpy.arange(15).reshape(3, 5)
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT numpy_test();
+ numpy_test
+------------
+ Success!
+(1 row)
+
+DROP FUNCTION numpy_test();
+--
+-- import scipy
+--
+create or replace function scipy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+import scipy
+f = lambda x: -scipy.special.jv(3, x)
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT scipy_test();
+ scipy_test
+------------
+ Success!
+(1 row)
+
+DROP FUNCTION scipy_test();
+--
+-- import pandas
+--
+create or replace function pandas_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pandas
+import numpy
+s = pandas.Series([1,3,5,numpy.nan,6,8])
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT pandas_test();
+ pandas_test
+-------------
+ Success!
+(1 row)
+
+DROP FUNCTION pandas_test();
+--
+-- import pyLDAvis
+--
+create or replace function pyldavis_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pyLDAvis
+version = pyLDAvis.__version__
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT pyldavis_test();
+ pyldavis_test
+---------------
+ Success!
+(1 row)
+
+DROP FUNCTION pyldavis_test();
+--
+-- import gensim
+--
+create or replace function gensim_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import gensim
+corpus = [[(0, 1.0), (1, 1.0), (2, 1.0)],[(2, 1.0), (3, 1.0), (4, 1.0), (5, 1.0), (6, 1.0), (8, 1.0)]]
+tfidf = gensim.models.TfidfModel(corpus)
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT gensim_test();
+ gensim_test
+-------------
+ Success!
+(1 row)
+
+DROP FUNCTION gensim_test();
+--
+-- import xgboost
+--
+create or replace function xgboost_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy as np
+import xgboost as xgb
+# generate data in numpy
+data = np.random.rand(5,10)
+label = np.random.randint(2, size=5)
+
+dtrain = xgb.DMatrix( data, label=label)
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT xgboost_test();
+ xgboost_test
+--------------
+ Success!
+(1 row)
+
+DROP FUNCTION xgboost_test();
+--
+-- import sklearn
+--
+create or replace function sklearn_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from sklearn import datasets
+from sklearn.cross_validation import cross_val_predict
+from sklearn import linear_model
+lr = linear_model.LinearRegression()
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT sklearn_test();
+ sklearn_test
+--------------
+ Success!
+(1 row)
+
+DROP FUNCTION sklearn_test();
+--
+-- import lifelines
+--
+create or replace function lifelines_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import lifelines
+cph = lifelines.CoxPHFitter()
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT lifelines_test();
+ lifelines_test
+----------------
+ Success!
+(1 row)
+
+DROP FUNCTION lifelines_test();
+--
+-- import pattern
+--
+create or replace function pattern_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pattern.en
+from pattern.web import Twitter
+twitter = Twitter()
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT pattern_test();
+ pattern_test
+--------------
+ Success!
+(1 row)
+
+DROP FUNCTION pattern_test();
+--
+-- download spacy
+--
+\! python -m spacy download en
+/usr/local/greenplum-db-devel/ext/python/bin/python: No module named spacy
+create or replace function spacy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+import spacy
+nlp = spacy.load('en')
+doc = nlp(u'this is a spacy tokenizer test.')
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT spacy_test();
+ spacy_test
+------------
+ Success!
+(1 row)
+
+DROP FUNCTION spacy_test();
+--
+-- import lxml
+--
+create or replace function lxml_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import lxml
+from lxml import etree
+xml = '<a xmlns="test"><b xmlns="test"/></a>'
+t = etree.fromstring(xml)
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT lxml_test();
+ lxml_test
+-----------
+ Success!
+(1 row)
+
+DROP FUNCTION lxml_test();
+--
+-- import statsmodels
+--
+create or replace function statsmodels_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy as np
+import statsmodels.nonparametric.api as nparam
+italy_gdp =[8.556, 12.262, 9.587, 8.119, 5.537, 6.796, 8.638]
+italy_year = [1951, 1951, 1951, 1951, 1951, 1951, 1951]
+italy_year = np.asarray(italy_year, float)
+model = nparam.KernelReg(endog=[italy_gdp],
+                         exog=[italy_year],
+                         reg_type='lc',
+                         var_type='o',
+                         bw='cv_ls')
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT statsmodels_test();
+ statsmodels_test
+------------------
+ Success!
+(1 row)
+
+DROP FUNCTION statsmodels_test();
+--
+-- import BeautifulSoup
+--
+create or replace function beautifulsoup_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from bs4 import BeautifulSoup
+text="<!DOCTYPE html><!--STATUS OK--><html> <head>TEST</head><body>TEST bs4</body></html>"
+soup=BeautifulSoup(text, "lxml")
+result = soup.find_all('head')
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT beautifulsoup_test();
+ beautifulsoup_test
+--------------------
+ Success!
+(1 row)
+
+DROP FUNCTION beautifulsoup_test();
+--
+-- import pymc3
+--
+create or replace function pymc3_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from pymc3 import Model, Normal, HalfNormal
+basic_model = Model()
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT pymc3_test();
+ pymc3_test
+------------
+ Success!
+(1 row)
+
+DROP FUNCTION pymc3_test();
+--
+-- import nltk
+--
+create or replace function nltk_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import nltk
+version=nltk.__version__
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT nltk_test();
+ nltk_test
+-----------
+ Success!
+(1 row)
+
+DROP FUNCTION nltk_test();
+--
+-- import keras
+--
+create or replace function keras_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+sys.argv=['']
+from keras.models import Sequential
+model = Sequential()
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT keras_test();
+ keras_test
+------------
+ Success!
+(1 row)
+
+DROP FUNCTION keras_test();
+--
+-- import tensorflow
+--
+create or replace function tensorflow_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+sys.argv=['']
+import tensorflow as tf
+hello = tf.constant('Hello, TensorFlow!')
+sess = tf.Session()
+print(sess.run(hello))
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+SELECT tensorflow_test();
+ tensorflow_test
+-----------------
+ Success!
+(1 row)
+
+DROP FUNCTION tensorflow_test();

--- a/tests/expected/r_import_library.out
+++ b/tests/expected/r_import_library.out
@@ -1,0 +1,158 @@
+CREATE OR REPLACE FUNCTION rint2(i int2) RETURNS int2 AS $$
+# container: plc_r_shared
+library()
+library(BH)
+library(DBI)
+library(MASS)
+library(MCMCpack)
+library(Matrix)
+library(rjags)
+library(R2jags)
+library(R6)
+library(RColorBrewer)
+library(ROCR)
+library(Rcpp)
+library(RcppEigen)
+library(RobustRankAggreg)
+library(SparseM)
+library(abind)
+library(adabag)
+library(arm)
+library(assertthat)
+library(bitops)
+library(caTools)
+library(car)
+library(caret)
+library(coda)
+library(colorspace)
+library(compHclust)
+library(curl)
+library(data.table)
+library(dichromat)
+library(digest)
+library(dplyr)
+library(e1071)
+library(flashClust)
+library(foreign)
+library(gdata)
+library(ggplot2)
+library(glmnet)
+library(gplots)
+library(gtable)
+library(gtools)
+library(hms)
+library(hybridHclust)
+library(igraph)
+library(labeling)
+library(lattice)
+library(lazyeval)
+library(lme4)
+library(lmtest)
+library(magrittr)
+library(minqa)
+library(munsell)
+library(neuralnet)
+library(nloptr)
+library(nnet)
+library(pbkrtest)
+library(plyr)
+library(quantreg)
+library(randomForest)
+library(readr)
+library(reshape2)
+library(rpart)
+library(sandwich)
+library(scales)
+library(stringi)
+library(stringr)
+library(survival)
+library(tibble)
+library(tseries)
+library(zoo)
+library(MTS)
+library(forecast)
+library(RPostgreSQL)
+set.seed(101)
+if (names(dev.cur()) != "null device") dev.off()
+pdf("/tmp/Rplots.pdf")
+x <- matrix(rnorm(500),5,100)
+x <- rbind(x,x[rep(1,4),]+matrix(rnorm(400),4,100))
+x <- rbind(x,x[2:5,]+matrix(rnorm(400),4,100))
+par(mfrow=c(1,2))
+e1 <- eisenCluster(x,'correlation')
+
+#nloptr
+eval_f <- function(y) {
+    return( 100 * (y[2] - y[1] * y[1])^2 + (1 - y[1])^2 )
+}
+
+eval_grad_f <- function(y) {
+    return( c( -400 * y[1] * (y[2] - y[1] * y[1]) - 2 * (1 - y[1]),
+                200 * (y[2] - y[1] * y[1])) )
+}
+
+x0 <- c( -1.2, 1 )
+
+opts <- list("algorithm"="NLOPT_LD_LBFGS",
+             "xtol_rel"=1.0e-8)
+
+res <- nloptr( x0=x0,
+               eval_f=eval_f,
+               eval_grad_f=eval_grad_f,
+               opts=opts)
+eval_f_list <- function(y) {
+    return( list( "objective" = 100 * (y[2] - y[1] * y[1])^2 + (1 - y[1])^2,
+                  "gradient"  = c( -400 * y[1] * (y[2] - y[1] * y[1]) - 2 * (1 - y[1]),
+                                    200 * (y[2] - y[1] * y[1])) ) )
+}
+
+# solve Rosenbrock Banana function using an objective function that
+# returns a list with the objective value and its gradient
+res <- nloptr( x0=x0,
+               eval_f=eval_f_list,
+               opts=opts)
+
+#stringr
+str_length("abc")
+sx <- c("abcdef", "ghifjk")
+str_sub(sx, 3, 3)
+
+#hms
+hms(666)
+
+#digest
+digest("r algorithm", algo="sha256")
+
+#pbkrtest
+data(beets, package="pbkrtest")
+head(beets)
+
+## Linear mixed effects model:
+sug   <- lmer(sugpct ~ block + sow + harvest + (1|block:harvest), data=beets, REML=FALSE)
+sug.h <- update(sug, .~. -harvest)
+sug.s <- update(sug, .~. -sow)
+
+#RcppEigen
+Rsamp <- function(X) {
+        stopifnot(is.numeric(X <- as.matrix(X)),
+                     (nc <- ncol(X)) > 1L,
+                          all(X >= 0))
+        apply(X, 1L, function(x) sample(nc, size=1L, replace=FALSE, prob=x+1e-10))
+}
+
+#abind
+xx <- matrix(1:12,3,4)
+yy <- xx+100
+dim(abind(xx,yy,along=0))     # binds on new dimension before first
+dim(abind(xx,yy,along=1))     # binds on first dimension
+dim(abind(xx,yy,along=1.5))
+
+return (as.integer(i))
+$$ LANGUAGE plcontainer;
+select rint2(1::int2);
+ rint2
+-------
+     1
+(1 row)
+
+DROP FUNCTION rint2(i int2);

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -42,5 +42,8 @@ test: memory_consuming_python memory_consuming_r
 test: memory_parallel_python memory_parallel_r
 test: memory_parallel_python_1 memory_parallel_python_2 memory_parallel_python_3 memory_parallel_python_4 memory_parallel_python_5 memory_parallel_r_1 memory_parallel_r_2 memory_parallel_r_3 memory_parallel_r_4 memory_parallel_r_5
 
+# PL/Container import pkg test
+test: python_import_module r_import_library
+
 # Drop the extension - need to be last
 test: drop

--- a/tests/sql/python_import_module.sql
+++ b/tests/sql/python_import_module.sql
@@ -1,0 +1,294 @@
+--
+-- import numpy
+--
+create or replace function numpy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy
+a = numpy.arange(15).reshape(3, 5)
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT numpy_test();
+
+DROP FUNCTION numpy_test();
+
+
+--
+-- import scipy
+--
+create or replace function scipy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+import scipy
+f = lambda x: -scipy.special.jv(3, x)
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT scipy_test();
+
+DROP FUNCTION scipy_test();
+
+
+--
+-- import pandas
+--
+create or replace function pandas_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pandas
+import numpy
+s = pandas.Series([1,3,5,numpy.nan,6,8])
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT pandas_test();
+
+DROP FUNCTION pandas_test();
+
+
+--
+-- import pyLDAvis
+--
+create or replace function pyldavis_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pyLDAvis
+version = pyLDAvis.__version__
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT pyldavis_test();
+
+DROP FUNCTION pyldavis_test();
+
+
+--
+-- import gensim
+--
+create or replace function gensim_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import gensim
+corpus = [[(0, 1.0), (1, 1.0), (2, 1.0)],[(2, 1.0), (3, 1.0), (4, 1.0), (5, 1.0), (6, 1.0), (8, 1.0)]]
+tfidf = gensim.models.TfidfModel(corpus)
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT gensim_test();
+
+DROP FUNCTION gensim_test();
+
+
+--
+-- import xgboost
+--
+create or replace function xgboost_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy as np
+import xgboost as xgb
+# generate data in numpy
+data = np.random.rand(5,10)
+label = np.random.randint(2, size=5)
+
+dtrain = xgb.DMatrix( data, label=label)
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT xgboost_test();
+
+DROP FUNCTION xgboost_test();
+
+
+--
+-- import sklearn
+--
+create or replace function sklearn_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from sklearn import datasets
+from sklearn.cross_validation import cross_val_predict
+from sklearn import linear_model
+lr = linear_model.LinearRegression()
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT sklearn_test();
+
+DROP FUNCTION sklearn_test();
+
+
+--
+-- import lifelines
+--
+create or replace function lifelines_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import lifelines
+cph = lifelines.CoxPHFitter()
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT lifelines_test();
+
+DROP FUNCTION lifelines_test();
+
+
+--
+-- import pattern
+--
+create or replace function pattern_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import pattern.en
+from pattern.web import Twitter
+twitter = Twitter()
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT pattern_test();
+
+DROP FUNCTION pattern_test();
+
+
+--
+-- download spacy
+--
+\! python -m spacy download en
+create or replace function spacy_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+import spacy
+nlp = spacy.load('en')
+doc = nlp(u'this is a spacy tokenizer test.')
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT spacy_test();
+
+DROP FUNCTION spacy_test();
+
+
+--
+-- import lxml
+--
+create or replace function lxml_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import lxml
+from lxml import etree
+xml = '<a xmlns="test"><b xmlns="test"/></a>'
+t = etree.fromstring(xml)
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT lxml_test();
+
+DROP FUNCTION lxml_test();
+
+
+--
+-- import statsmodels
+--
+create or replace function statsmodels_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import numpy as np
+import statsmodels.nonparametric.api as nparam
+italy_gdp =[8.556, 12.262, 9.587, 8.119, 5.537, 6.796, 8.638]
+italy_year = [1951, 1951, 1951, 1951, 1951, 1951, 1951]
+italy_year = np.asarray(italy_year, float)
+model = nparam.KernelReg(endog=[italy_gdp],
+                         exog=[italy_year],
+                         reg_type='lc',
+                         var_type='o',
+                         bw='cv_ls')
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT statsmodels_test();
+
+DROP FUNCTION statsmodels_test();
+
+
+--
+-- import BeautifulSoup
+--
+create or replace function beautifulsoup_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from bs4 import BeautifulSoup 
+text="<!DOCTYPE html><!--STATUS OK--><html> <head>TEST</head><body>TEST bs4</body></html>"
+soup=BeautifulSoup(text, "lxml")
+result = soup.find_all('head')
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT beautifulsoup_test();
+
+DROP FUNCTION beautifulsoup_test();
+
+
+--
+-- import pymc3
+--
+create or replace function pymc3_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+from pymc3 import Model, Normal, HalfNormal
+basic_model = Model()
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT pymc3_test();
+
+DROP FUNCTION pymc3_test();
+
+
+--
+-- import nltk
+--
+create or replace function nltk_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import nltk
+version=nltk.__version__
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT nltk_test();
+
+DROP FUNCTION nltk_test();
+
+
+--
+-- import keras
+--
+create or replace function keras_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+sys.argv=['']
+from keras.models import Sequential
+model = Sequential()
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT keras_test();
+
+DROP FUNCTION keras_test();
+
+
+--
+-- import tensorflow
+--
+create or replace function tensorflow_test() RETURNS TEXT AS $$
+# container: plc_python_shared
+import sys
+sys.argv=['']
+import tensorflow as tf
+hello = tf.constant('Hello, TensorFlow!')
+sess = tf.Session()
+print(sess.run(hello))
+
+return "Success!"
+$$ LANGUAGE plcontainer;
+
+SELECT tensorflow_test();
+
+DROP FUNCTION tensorflow_test();

--- a/tests/sql/r_import_library.sql
+++ b/tests/sql/r_import_library.sql
@@ -1,0 +1,155 @@
+CREATE OR REPLACE FUNCTION rint2(i int2) RETURNS int2 AS $$
+# container: plc_r_shared
+library()
+library(BH)
+library(DBI)
+library(MASS)
+library(MCMCpack)
+library(Matrix)
+library(rjags)
+library(R2jags)
+library(R6)
+library(RColorBrewer)
+library(ROCR)
+library(Rcpp)
+library(RcppEigen)
+library(RobustRankAggreg)
+library(SparseM)
+library(abind)
+library(adabag)
+library(arm)
+library(assertthat)
+library(bitops)
+library(caTools)
+library(car)
+library(caret)
+library(coda)
+library(colorspace)
+library(compHclust)
+library(curl)
+library(data.table)
+library(dichromat)
+library(digest)
+library(dplyr)
+library(e1071)
+library(flashClust)
+library(foreign)
+library(gdata)
+library(ggplot2)
+library(glmnet)
+library(gplots)
+library(gtable)
+library(gtools)
+library(hms)
+library(hybridHclust)
+library(igraph)
+library(labeling)
+library(lattice)
+library(lazyeval)
+library(lme4)
+library(lmtest)
+library(magrittr)
+library(minqa)
+library(munsell)
+library(neuralnet)
+library(nloptr)
+library(nnet)
+library(pbkrtest)
+library(plyr)
+library(quantreg)
+library(randomForest)
+library(readr)
+library(reshape2)
+library(rpart)
+library(sandwich)
+library(scales)
+library(stringi)
+library(stringr)
+library(survival)
+library(tibble)
+library(tseries)
+library(zoo)
+library(MTS)
+library(forecast)
+library(RPostgreSQL)
+set.seed(101)
+if (names(dev.cur()) != "null device") dev.off()
+pdf("/tmp/Rplots.pdf")
+x <- matrix(rnorm(500),5,100)
+x <- rbind(x,x[rep(1,4),]+matrix(rnorm(400),4,100))
+x <- rbind(x,x[2:5,]+matrix(rnorm(400),4,100))
+par(mfrow=c(1,2))
+e1 <- eisenCluster(x,'correlation')
+
+#nloptr
+eval_f <- function(y) {
+    return( 100 * (y[2] - y[1] * y[1])^2 + (1 - y[1])^2 )
+}
+
+eval_grad_f <- function(y) {
+    return( c( -400 * y[1] * (y[2] - y[1] * y[1]) - 2 * (1 - y[1]),
+                200 * (y[2] - y[1] * y[1])) )
+}
+
+x0 <- c( -1.2, 1 )
+
+opts <- list("algorithm"="NLOPT_LD_LBFGS",
+             "xtol_rel"=1.0e-8)
+
+res <- nloptr( x0=x0,
+               eval_f=eval_f,
+               eval_grad_f=eval_grad_f,
+               opts=opts)
+eval_f_list <- function(y) {
+    return( list( "objective" = 100 * (y[2] - y[1] * y[1])^2 + (1 - y[1])^2,
+                  "gradient"  = c( -400 * y[1] * (y[2] - y[1] * y[1]) - 2 * (1 - y[1]),
+                                    200 * (y[2] - y[1] * y[1])) ) )
+}
+
+# solve Rosenbrock Banana function using an objective function that
+# returns a list with the objective value and its gradient
+res <- nloptr( x0=x0,
+               eval_f=eval_f_list,
+               opts=opts)
+
+#stringr
+str_length("abc")
+sx <- c("abcdef", "ghifjk")
+str_sub(sx, 3, 3)
+
+#hms
+hms(666)
+
+#digest
+digest("r algorithm", algo="sha256")
+
+#pbkrtest
+data(beets, package="pbkrtest")
+head(beets)
+
+## Linear mixed effects model:
+sug   <- lmer(sugpct ~ block + sow + harvest + (1|block:harvest), data=beets, REML=FALSE)
+sug.h <- update(sug, .~. -harvest)
+sug.s <- update(sug, .~. -sow)
+
+#RcppEigen
+Rsamp <- function(X) {
+        stopifnot(is.numeric(X <- as.matrix(X)),
+                     (nc <- ncol(X)) > 1L,
+                          all(X >= 0))
+        apply(X, 1L, function(x) sample(nc, size=1L, replace=FALSE, prob=x+1e-10))
+}
+
+#abind
+xx <- matrix(1:12,3,4)
+yy <- xx+100
+dim(abind(xx,yy,along=0))     # binds on new dimension before first
+dim(abind(xx,yy,along=1))     # binds on first dimension
+dim(abind(xx,yy,along=1.5))
+
+return (as.integer(i))
+$$ LANGUAGE plcontainer;
+
+select rint2(1::int2);
+
+DROP FUNCTION rint2(i int2);


### PR DESCRIPTION
Add datasciencebundle regression tests to plcontainer

To make  datasciencebundle regression tests also run success on plcontainer, we have to change code in datasciencebundle,  because plcontainer's  base image  come from datasciencebundle.

Datasciencebundle changes refer to: https://github.com/greenplum-db/data-science-bundle/pull/41