### PR TITLE
Support User Access Control White List For Selected Runtimes

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -443,7 +443,7 @@ def validate_xml(filename):
         image_list.append(line)
     correct = True
     try:
-        xmltree = ElementTree.parse(filename);
+        xmltree = ElementTree.parse(filename)
         root = xmltree.getroot()
         for runtime in root.findall('runtime'):
 
@@ -545,6 +545,11 @@ def validate_xml(filename):
                     resource_group_id_str = settings.attrib['resource_group_id']
                     if resource_group_id_str.isdigit() != True:
                         logger.error("'resource_group_id_str' cannot contain non-digit, it should be oid of resource group")
+                        raise Exception("Validation failed")
+                elif 'users' in settings.attrib:
+                    users_str = settings.attrib['users']
+                    if not users_str:
+                        logger.error("'users_str' is empty, please add users (separate with ',') or remove this element")
                         raise Exception("Validation failed")
                 else:
                     logger.error("Found illegal setting in runtime %s: %s", runtime_id, settings.attrib)
@@ -656,8 +661,8 @@ def runtime_show_xml(filename, r_id):
     :return: 
     '''
     try:
-        no_entry = True;
-        xmltree = ElementTree.parse(filename);
+        no_entry = True
+        xmltree = ElementTree.parse(filename)
         root = xmltree.getroot()
         sys.stdout.write("PL/Container Runtime Configuration: \n")
         for runtime in root.findall('runtime'):
@@ -678,6 +683,8 @@ def runtime_show_xml(filename, r_id):
                         sys.stdout.write("  ---- Use Container Logging: %s\n" % settings.attrib['use_container_logging'])
                     elif 'resource_group_id' in settings.attrib:
                         sys.stdout.write("  ---- Resource Group ID: %s\n" % settings.attrib['resource_group_id'])
+                    elif 'users' in settings.attrib:
+                        sys.stdout.write("  ---- Allowed Users: %s\n" % settings.attrib['users'])
                 sys.stdout.write("  Shared Directory: \n")
                 for share_folder in runtime.findall('shared_directory'):
                     sys.stdout.write("  ---- Shared Directory From HOST '%s' to Container '%s', access mode is '%s'\n" % (share_folder.attrib['host'], share_folder.attrib['container'], share_folder.attrib['access']))
@@ -701,7 +708,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "memory_mb" and strList[0] != "cpu_share" and strList[0] != "use_container_logging" and strList[0] != "resource_group_id":
+        if strList[0] != "memory_mb" and strList[0] != "cpu_share" and strList[0] != "use_container_logging" and strList[0] != "resource_group_id" and strList[0] != "users":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 
@@ -761,7 +768,7 @@ def checkAllFileMD5(pool, gpdb_locations):
     results = None
     for i in items:
         if i.results.rc or i.results.halt or not i.results.completed:
-            logger.error("error running command: %s" % cmd_str)
+            logger.error("error running command")
             raise Exception("error running command")
         # Put the QD conf file MD5 into resluts and do comparison
         if results is None:

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -546,10 +546,10 @@ def validate_xml(filename):
                     if resource_group_id_str.isdigit() != True:
                         logger.error("'resource_group_id_str' cannot contain non-digit, it should be oid of resource group")
                         raise Exception("Validation failed")
-                elif 'users' in settings.attrib:
-                    users_str = settings.attrib['users']
-                    if not users_str:
-                        logger.error("'users_str' is empty, please add users (separate with ',') or remove this element")
+                elif 'roles' in settings.attrib:
+                    roles_str = settings.attrib['roles']
+                    if not roles_str:
+                        logger.error("'roles_str' is empty, please add roles (separate with ',') or remove this element")
                         raise Exception("Validation failed")
                 else:
                     logger.error("Found illegal setting in runtime %s: %s", runtime_id, settings.attrib)
@@ -683,8 +683,8 @@ def runtime_show_xml(filename, r_id):
                         sys.stdout.write("  ---- Use Container Logging: %s\n" % settings.attrib['use_container_logging'])
                     elif 'resource_group_id' in settings.attrib:
                         sys.stdout.write("  ---- Resource Group ID: %s\n" % settings.attrib['resource_group_id'])
-                    elif 'users' in settings.attrib:
-                        sys.stdout.write("  ---- Allowed Users: %s\n" % settings.attrib['users'])
+                    elif 'roles' in settings.attrib:
+                        sys.stdout.write("  ---- Allowed Roles: %s\n" % settings.attrib['roles'])
                 sys.stdout.write("  Shared Directory: \n")
                 for share_folder in runtime.findall('shared_directory'):
                     sys.stdout.write("  ---- Shared Directory From HOST '%s' to Container '%s', access mode is '%s'\n" % (share_folder.attrib['host'], share_folder.attrib['container'], share_folder.attrib['access']))
@@ -708,7 +708,7 @@ def get_conf_settings(options, elements):
         strList = setting.split("=")
         if len(strList) != 2:
             raise Exception("Bad setting format: %s" % setting)
-        if strList[0] != "memory_mb" and strList[0] != "cpu_share" and strList[0] != "use_container_logging" and strList[0] != "resource_group_id" and strList[0] != "users":
+        if strList[0] != "memory_mb" and strList[0] != "cpu_share" and strList[0] != "use_container_logging" and strList[0] != "resource_group_id" and strList[0] != "roles":
             raise Exception("Bad setting key: %s" % strList[0])
         elements['setting'][strList[0]] = strList[1]
 

--- a/src/containers.c
+++ b/src/containers.c
@@ -366,7 +366,7 @@ static char *get_uds_fn(char *uds_dir) {
 
 	/* filename: IPC_GPDB_BASE_DIR + "." + PID + "." + DOMAIN_SOCKET_NO  + "." + container_slot / UDS_SHARED_FILE */
 	sz = strlen(uds_dir) + 1 + MAX_SHARED_FILE_SZ + 1;
-	uds_fn = pmalloc(sz);
+	uds_fn = (char*) pmalloc(sz);
 	snprintf(uds_fn, sz, "%s/%s", uds_dir, UDS_SHARED_FILE);
 
 	return uds_fn;
@@ -498,7 +498,7 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 	 * CONTAINER_CONNECT_TIMEOUT_MS is reached. Exponential backoff for
 	 * reconnecting first attempts: 25ms, 50ms, 100ms, 200ms, 200ms, etc.
 	 */
-	mping = palloc(sizeof(plcMsgPing));
+	mping = (plcMsgPing*) palloc(sizeof(plcMsgPing));
 	mping->msgtype = MT_PING;
 	while (sleepms < CONTAINER_CONNECT_TIMEOUT_MS) {
 		int res = 0;

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -23,6 +23,7 @@
 #include "utils/guc.h"
 #include "libpq/libpq-be.h"
 #include "funcapi.h"
+#include "utils/acl.h"
 
 #include "common/comm_utils.h"
 #include "common/comm_connectivity.h"
@@ -164,6 +165,8 @@ static void parse_runtime_configuration(xmlNode *node) {
 		conf_entry->useContainerLogging = false;
 		conf_entry->useContainerNetwork = false;
 		conf_entry->resgroupOid = InvalidOid;
+		conf_entry->useUserControl = false;
+		conf_entry->users = NULL;
 
 
 		for (cur_node = node->children; cur_node; cur_node = cur_node->next) {
@@ -262,6 +265,19 @@ static void parse_runtime_configuration(xmlNode *node) {
 						xmlFree((void *) value);
 						value = NULL;
 					}
+
+					value = xmlGetProp(cur_node, (const xmlChar *) "users");
+					if (value != NULL) {
+						validSetting = true;
+						if (strlen((char *) value) == 0) {
+							plc_elog(ERROR, "SETTING length of element <users> is zero");
+						}
+						conf_entry->users = plc_top_strdup((char *) value);
+						conf_entry->useUserControl = true;
+						xmlFree((void *) value);
+						value = NULL;
+					}
+
 					if (!validSetting) {
 						plc_elog(ERROR, "Unrecognized setting options, please check the configuration file: %s", conf_entry->runtimeid);
 					}
@@ -430,6 +446,9 @@ static void print_runtime_configurations() {
 			plc_elog(INFO, "    memory_mb = '%d'", conf_entry->memoryMb);
 			plc_elog(INFO, "    cpu_share = '%d'", conf_entry->cpuShare);
 			plc_elog(INFO, "    use container logging  = '%s'", conf_entry->useContainerLogging ? "yes" : "no");
+			if (conf_entry->useUserControl){
+				plc_elog(INFO, "    allowed users list  = '%s'", conf_entry->users);
+			}
 			if (conf_entry->resgroupOid != InvalidOid)
 			{
 				plc_elog(INFO, "    resource group id  = '%u'", conf_entry->resgroupOid);
@@ -844,5 +863,36 @@ containers_summary(pg_attribute_unused() PG_FUNCTION_ARGS) {
 			SRF_RETURN_DONE(funcctx);
 		}
 	}
+
+}
+
+bool plc_check_user_privilege(char *users){
+
+	List *elemlist;
+	ListCell *l;
+	Oid currentUserOid;
+
+	if (!SplitIdentifierString(users, ',', &elemlist))
+	{
+		list_free(elemlist);
+		elog(ERROR, "Could not get user list from %s, please check it again", users);
+	}
+
+	currentUserOid = GetUserId();
+
+	if (currentUserOid == InvalidDbid){
+		elog(ERROR, "Could not get current user Oid");
+	}
+
+	foreach(l, elemlist)
+	{
+		char *user = (char*) lfirst(l);
+		Oid userOid = get_role_oid(user, true);
+		if (userOid == currentUserOid){
+			return true;
+		}
+	}
+
+	return false;
 
 }

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -45,6 +45,7 @@ typedef struct runtimeConfEntry {
 	char runtimeid[RUNTIME_ID_MAX_LENGTH];
 	char *image;
 	char *command;
+	char *users;
 	Oid resgroupOid;
 	int memoryMb;
 	int cpuShare;
@@ -52,6 +53,7 @@ typedef struct runtimeConfEntry {
 	plcSharedDir *sharedDirs;
 	bool useContainerNetwork;
 	bool useContainerLogging;
+	bool useUserControl;
 } runtimeConfEntry;
 
 /* entrypoint for all plcontainer procedures */
@@ -62,6 +64,8 @@ Datum show_plcontainer_config(PG_FUNCTION_ARGS);
 Datum containers_summary(PG_FUNCTION_ARGS);
 
 runtimeConfEntry *plc_get_runtime_configuration(char *id);
+
+bool plc_check_user_privilege(char *users);
 
 char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_error, char **uds_dir);
 

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -45,7 +45,7 @@ typedef struct runtimeConfEntry {
 	char runtimeid[RUNTIME_ID_MAX_LENGTH];
 	char *image;
 	char *command;
-	char *users;
+	char *roles;
 	Oid resgroupOid;
 	int memoryMb;
 	int cpuShare;

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -234,7 +234,7 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 		 */
 
 		if (runtime_conf_entry->useUserControl) {
-			if (!plc_check_user_privilege(runtime_conf_entry->users)){
+			if (!plc_check_user_privilege(runtime_conf_entry->roles)){
 				plc_elog(ERROR, "Current user does not have privilege to use runtime %s", runtime_id);
 			}
 		}

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -221,20 +221,32 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 		result = NULL;
 		req = plcontainer_create_call(fcinfo, pinfo);
 		runtime_id = parse_container_meta(req->proc.src);
-		conn = get_container_conn(runtime_id);
-		if (conn == NULL) {
-			runtimeConfEntry *runtime_conf_entry = NULL;
-			runtime_conf_entry = plc_get_runtime_configuration(runtime_id);
-			if (runtime_conf_entry == NULL) {
-				plc_elog(ERROR, "Runtime '%s' is not defined in configuration "
-							"and cannot be used", runtime_id);
-			} else {
-				/* TODO: We could only remove this backend when error occurs. */
-				DeleteBackendsWhenError = true;
-				conn = start_backend(runtime_conf_entry);
-				DeleteBackendsWhenError = false;
+		
+		runtimeConfEntry *runtime_conf_entry = NULL;
+		runtime_conf_entry = plc_get_runtime_configuration(runtime_id);
+
+		if (runtime_conf_entry == NULL) {
+			plc_elog(ERROR, "Runtime '%s' is not defined in configuration "
+						"and cannot be used", runtime_id);
+		} 
+		/*
+		 * We need to check the privilege in each run
+		 */
+
+		if (runtime_conf_entry->useUserControl) {
+			if (!plc_check_user_privilege(runtime_conf_entry->users)){
+				plc_elog(ERROR, "Current user does not have privilege to use runtime %s", runtime_id);
 			}
 		}
+
+		conn = get_container_conn(runtime_id);
+		if (conn == NULL) {
+			/* TODO: We could only remove this backend when error occurs. */
+			DeleteBackendsWhenError = true;
+			conn = start_backend(runtime_conf_entry);
+			DeleteBackendsWhenError = false;
+		}
+
 		pfree(runtime_id);
 
 		DeleteBackendsWhenError = true;

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -32,6 +32,7 @@ test: oom_test_python_killed oom_test_python_killed_1 oom_test_python_normal oom
 
 # Miscellaneous test
 test: misc
+test: user_control
 
 # PL/Container parallel test (io & cpu)
 test: parallel_prepare


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
1. Each runtime now support user white list, once set,
   a user could use this runtime to run UDF only if this
   user is in white list.
2. A new setting attribute "users" is used for white list.
   For example,
   ```
   <users>gpadmin</users>
   ```
   can only allow gpadmin user/role to use this runtime.
3. Add related regression tests

## Tests
<!-- describe your test -->
Regression tests added
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
