### PR TITLE
 remove todo for parseTypeString arguments

### DIFF
--- a/src/sqlhandler.c
+++ b/src/sqlhandler.c
@@ -345,7 +345,7 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 				for (i = 0; i < msg->nargs; i++) {
 					if (msg->args[i].type.type == PLC_DATA_TEXT) {
 #ifdef PLC_PG
-						parseTypeString(msg->args[i].type.typeName, &type_oid, &typemod, false);  //todo
+						parseTypeString(msg->args[i].type.typeName, &type_oid, &typemod, false);
 #else						
 						parseTypeString(msg->args[i].type.typeName, &type_oid, &typemod);
 #endif						


### PR DESCRIPTION
As discussed with @zhangh43 in issue #369, an argument was added in postgres to the parseTypeString function; The argument allows the function to return "InvalidOid" without error, in case no matching type was found.
To keep behaviour similar to gpdb, this argument needs to be set to false.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Tests
<!-- describe your test -->

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
