### PR TITLE
Fix arg number mismatch caused by OUT parameter.

### DIFF
--- a/tests/expected/function_python.out
+++ b/tests/expected/function_python.out
@@ -528,3 +528,7 @@ CREATE FUNCTION pythonlogging_fatal() RETURNS void AS $$
 # container: plc_python_shared
 plpy.fatal("test plpy fatal")
 $$ LANGUAGE plcontainer;
+CREATE FUNCTION multiout_simple_setof(n integer = 1, OUT integer) AS $$
+# container: plc_python_shared
+return 1
+$$ language plcontainer;

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -694,7 +694,7 @@ SELECT py_udt_return_null();
 (1 row)
 
 select multiout_simple_setof();
- multiout_simple_setof
+ multiout_simple_setof 
 -----------------------
                      1
 (1 row)

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -693,6 +693,12 @@ SELECT py_udt_return_null();
  (t,1,2,3,4,5,6,)
 (1 row)
 
+select multiout_simple_setof();
+ multiout_simple_setof
+-----------------------
+                     1
+(1 row)
+
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -694,7 +694,7 @@ SELECT py_udt_return_null();
 (1 row)
 
 select multiout_simple_setof();
- multiout_simple_setof
+ multiout_simple_setof 
 -----------------------
                      1
 (1 row)

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -693,6 +693,12 @@ SELECT py_udt_return_null();
  (t,1,2,3,4,5,6,)
 (1 row)
 
+select multiout_simple_setof();
+ multiout_simple_setof
+-----------------------
+                     1
+(1 row)
+
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/sql/function_python.sql
+++ b/tests/sql/function_python.sql
@@ -618,3 +618,8 @@ CREATE FUNCTION pythonlogging_fatal() RETURNS void AS $$
 # container: plc_python_shared
 plpy.fatal("test plpy fatal")
 $$ LANGUAGE plcontainer;
+
+CREATE FUNCTION multiout_simple_setof(n integer = 1, OUT integer) AS $$
+# container: plc_python_shared
+return 1
+$$ language plcontainer;

--- a/tests/sql/test_python.sql
+++ b/tests/sql/test_python.sql
@@ -117,4 +117,5 @@ select pybadarr2();
 select pyinvalid_function();
 select pysubtransaction('t');
 SELECT py_udt_return_null();
+select multiout_simple_setof();
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Argument length of function in catalog will not count OUT parameter in 'pronargs' field.
## Tests
<!-- describe your test -->
Test added 
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
#381