### PR TITLE
 Support plpy.Error and plpy.Fatal as exception

### DIFF
--- a/src/pyclient/plpy_spi.c
+++ b/src/pyclient/plpy_spi.c
@@ -954,7 +954,6 @@ static void
 PLy_add_exceptions(PyObject *plpy)
 {
 	PyObject *excmod;
-	HASHCTL hash_ctl;
 
 #if PY_MAJOR_VERSION < 3
 	excmod = Py_InitModule("spiexceptions", PLy_exc_methods);
@@ -962,17 +961,8 @@ PLy_add_exceptions(PyObject *plpy)
 	excmod = PyModule_Create(&PLy_exc_module);
 #endif
 	if (PyModule_AddObject(plpy, "spiexceptions", excmod) < 0)
-		PLy_elog(ERROR, "could not add the spiexceptions module");
+		plc_elog(ERROR, "could not add the spiexceptions module");
 
-	/*
-	 * XXX it appears that in some circumstances the reference count of the
-	 * spiexceptions module drops to zero causing a Python assert failure when
-	 * the garbage collector visits the module. This has been observed on the
-	 * buildfarm. To fix this, add an additional ref for the module here.
-	 *
-	 * This shouldn't cause a memory leak - we don't want this garbage collected,
-	 * and this function shouldn't be called more than once per backend.
-	 */
 	Py_INCREF(excmod);
 
 	PLy_exc_error = PyErr_NewException("plpy.Error", NULL, NULL);
@@ -986,14 +976,11 @@ PLy_add_exceptions(PyObject *plpy)
 	Py_INCREF(PLy_exc_spi_error);
 	PyModule_AddObject(plpy, "SPIError", PLy_exc_spi_error);
 
-	memset(&hash_ctl, 0, sizeof(hash_ctl));
-	hash_ctl.keysize = sizeof(int);
-	hash_ctl.entrysize = sizeof(PLyExceptionEntry);
-	hash_ctl.hash = tag_hash;
-	PLy_spi_exceptions = hash_create("SPI exceptions", 256, &hash_ctl,
-			HASH_ELEM | HASH_FUNCTION);
+	/*
+	 * TODO: lack detailed spi exception
+	 * refer to PLy_generate_spi_exceptions in upstream.
+	 */
 
-	PLy_generate_spi_exceptions(excmod, PLy_exc_spi_error);
 }
 
 #if PY_MAJOR_VERSION >= 3

--- a/tests/expected/function_python.out
+++ b/tests/expected/function_python.out
@@ -536,3 +536,33 @@ CREATE FUNCTION unicode_test_return() returns text as $$
 # container: plc_python_shared
 return u'\u0420'
 $$ LANGUAGE plcontainer;
+CREATE FUNCTION nested_error_raise() RETURNS text
+AS $$
+# container: plc_python_shared
+def fun1():
+    raise plpy.Error("boom")
+
+def fun2():
+    fun1()
+
+def fun3():
+    fun2()
+
+fun3()
+return "not reached"
+$$ LANGUAGE plcontainer;
+CREATE FUNCTION nested_fatal_raise() RETURNS text
+AS $$
+# container: plc_python_shared
+def fun1():
+    raise plpy.Fatal("boom")
+
+def fun2():
+    fun1()
+
+def fun3():
+    fun2()
+
+fun3()
+return "not reached"
+$$ LANGUAGE plcontainer;

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -705,6 +705,26 @@ select multiout_simple_setof();
                      1
 (1 row)
 
+select nested_error_raise();
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 13, in nested_error_raise
+  File "<string>", line 11, in fun3
+  File "<string>", line 8, in fun2
+  File "<string>", line 5, in fun1
+Error: boom
+select nested_fatal_raise();
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 13, in nested_fatal_raise
+  File "<string>", line 11, in fun3
+  File "<string>", line 8, in fun2
+  File "<string>", line 5, in fun1
+Fatal: boom
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -705,6 +705,26 @@ select multiout_simple_setof();
                      1
 (1 row)
 
+select nested_error_raise();
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 13, in nested_error_raise
+  File "<string>", line 11, in fun3
+  File "<string>", line 8, in fun2
+  File "<string>", line 5, in fun1
+Error: boom
+select nested_fatal_raise();
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 13, in nested_fatal_raise
+  File "<string>", line 11, in fun3
+  File "<string>", line 8, in fun2
+  File "<string>", line 5, in fun1
+Fatal: boom
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/sql/function_python.sql
+++ b/tests/sql/function_python.sql
@@ -628,3 +628,35 @@ CREATE FUNCTION unicode_test_return() returns text as $$
 # container: plc_python_shared
 return u'\u0420'
 $$ LANGUAGE plcontainer;
+
+CREATE FUNCTION nested_error_raise() RETURNS text
+AS $$
+# container: plc_python_shared
+def fun1():
+    raise plpy.Error("boom")
+
+def fun2():
+    fun1()
+
+def fun3():
+    fun2()
+
+fun3()
+return "not reached"
+$$ LANGUAGE plcontainer;
+
+CREATE FUNCTION nested_fatal_raise() RETURNS text
+AS $$
+# container: plc_python_shared
+def fun1():
+    raise plpy.Fatal("boom")
+
+def fun2():
+    fun1()
+
+def fun3():
+    fun2()
+
+fun3()
+return "not reached"
+$$ LANGUAGE plcontainer;

--- a/tests/sql/test_python.sql
+++ b/tests/sql/test_python.sql
@@ -119,4 +119,6 @@ select pysubtransaction('t');
 SELECT py_udt_return_null();
 select unicode_test_return();
 select multiout_simple_setof();
+select nested_error_raise();
+select nested_fatal_raise();
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
This is different from plpy.error. It's a new python exception type.
Also add TODO for "lack detailed spi exception" after comparing with upstream. refer to #431
## Tests
<!-- describe your test -->

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
#410 