### PR TITLE
Pass plpy exception to plcontainer instead of throw error directly.

### DIFF
--- a/src/common/comm_messages.c
+++ b/src/common/comm_messages.c
@@ -145,7 +145,9 @@ void free_result(plcMsgResult *res, bool isSender) {
 
 void free_rawmsg(plcMsgRaw *msg) {
 	if (msg != NULL) {
-		pfree(msg->data);
+		if (msg->data != NULL) {
+			pfree(msg->data);
+		}
 		pfree(msg);
 	}
 }

--- a/src/common/comm_utils.c
+++ b/src/common/comm_utils.c
@@ -31,7 +31,6 @@ PLy_strdup(const char *str)
 	return result;
 }
 
-
 char *plc_top_strdup(char *str) {
 	int len = strlen(str);
 	char *out = PLy_malloc(len + 1);

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -349,8 +349,23 @@ static void plcontainer_process_sql(plcMsgSQL *msg, plcConn *conn, plcProcInfo *
 	if (res != NULL) {
 		retval = plcontainer_channel_send(conn, res);
 		if (retval < 0) {
+			/*
+			 * SPI_execute may exit container(e.g. plpy.error)
+			 * in this case, we need to output the plpy.error message
+			 * to end user instead of 'Error sending data to the client'
+			 */
+			if (res->msgtype == MT_EXCEPTION) {
+				plcMsgError* errorResp = (plcMsgError *) res;
+				if (errorResp->message != NULL) {
+					plc_elog(ERROR, "Handle spi message failed due to error: %s",
+							errorResp->message);
+				} else {
+					plc_elog(ERROR, "Handle spi message failed.");
+				}
+			} else {
 			plc_elog(ERROR, "Error sending data to the client. "
 				"Maybe retry later.");
+			}
 			return;
 		}
 		switch (res->msgtype) {
@@ -362,6 +377,9 @@ static void plcontainer_process_sql(plcMsgSQL *msg, plcConn *conn, plcProcInfo *
 				break;
 			case MT_RAW:
 				free_rawmsg((plcMsgRaw *) res);
+				break;
+			case MT_EXCEPTION:
+				free_error((plcMsgError *) res);
 				break;
 			default:
 				ereport(ERROR,

--- a/src/pyclient/plpy_spi.c
+++ b/src/pyclient/plpy_spi.c
@@ -323,7 +323,7 @@ static plcMessage *receive_from_frontend() {
 	int res = 0;
 	plcConn *conn = plcconn_global;
 
-	res = plcontainer_channel_receive(conn, &resp, MT_CALLREQ_BIT | MT_RESULT_BIT | MT_SUBTRAN_RESULT_BIT| MT_EXCEPTION_BIT| MT_RAW_BIT);
+	res = plcontainer_channel_receive(conn, &resp, MT_PING_BIT| MT_CALLREQ_BIT | MT_RESULT_BIT | MT_SUBTRAN_RESULT_BIT| MT_EXCEPTION_BIT| MT_RAW_BIT);
 	if (res < 0) {
 		raise_execution_error("Error receiving data from the frontend, %d", res);
 		return NULL;
@@ -334,6 +334,9 @@ static plcMessage *receive_from_frontend() {
 			handle_call((plcMsgCallreq *) resp, conn);
 			free_callreq((plcMsgCallreq *) resp, false, false);
 			return receive_from_frontend();
+		case MT_PING:
+			plcontainer_channel_send(conn, resp);
+			return receive_from_frontend();			
 		case MT_RESULT:
 			break;
 		case MT_SUBTRAN_RESULT:

--- a/src/pyclient/plpy_spi.c
+++ b/src/pyclient/plpy_spi.c
@@ -7,6 +7,7 @@
  */
 #include "plpy_spi.h"
 
+#include <assert.h>
 #include "common/comm_channel.h"
 #include "common/comm_utils.h"
 #include "pycall.h"
@@ -21,6 +22,7 @@ typedef struct PLySubtransactionObject {
 	bool exited;
 } PLySubtransactionObject;
 
+static plcMessage *receive_from_frontend();
 
 static PyObject *PLy_subtransaction_new(void);
 
@@ -244,7 +246,6 @@ PLy_plan_new(void) {
 
 /* SPI_freeplan(ob->pplan) */
 static int PLy_freeplan(PLyPlanObject *ob) {
-	int res;
 	plcMsgSQL msg;
 	plcMessage *resp;
 	plcConn *conn = plcconn_global;
@@ -261,15 +262,28 @@ static int PLy_freeplan(PLyPlanObject *ob) {
 	plcontainer_channel_send(conn, (plcMessage *) &msg);
 	/* No need to free for msg after tx. */
 
-	res = plcontainer_channel_receive(conn, &resp, MT_RAW_BIT);
-	if (res < 0) {
-		raise_execution_error("Error receiving data from the frontend, %d", res);
-		return res;
+	resp = receive_from_frontend();
+	if (resp == NULL) {
+		raise_execution_error("Error receiving data from frontend");
+		return -1;
 	}
+	if (resp->msgtype == MT_EXCEPTION) {
+		plcMsgError* errorResp = (plcMsgError *) resp;
+		if (errorResp->message != NULL) {
+			PLy_exception_set(PLy_exc_spi_error,
+					"SPI free plan failed due to %s", errorResp->message);
+		} else {
+			PLy_exception_set(PLy_exc_spi_error, "SPI free plan failed.");
+		}
+		return -1;
+	}
+
 
 	int32 *prv;
 	prv = (int32 *) (((plcMsgRaw *) resp)->data);
-	res = *prv;
+	if(*prv != 0) {
+		PLy_exception_set(PLy_exc_spi_error, "SPI free plan failed.");
+	}
 
 	free_rawmsg((plcMsgRaw *) resp);
 	return 0;
@@ -309,7 +323,7 @@ static plcMessage *receive_from_frontend() {
 	int res = 0;
 	plcConn *conn = plcconn_global;
 
-	res = plcontainer_channel_receive(conn, &resp, MT_CALLREQ_BIT | MT_RESULT_BIT | MT_SUBTRAN_RESULT_BIT);
+	res = plcontainer_channel_receive(conn, &resp, MT_CALLREQ_BIT | MT_RESULT_BIT | MT_SUBTRAN_RESULT_BIT| MT_EXCEPTION_BIT| MT_RAW_BIT);
 	if (res < 0) {
 		raise_execution_error("Error receiving data from the frontend, %d", res);
 		return NULL;
@@ -323,6 +337,10 @@ static plcMessage *receive_from_frontend() {
 		case MT_RESULT:
 			break;
 		case MT_SUBTRAN_RESULT:
+			break;
+		case MT_EXCEPTION:
+			break;
+		case MT_RAW:
 			break;
 		default:
 			raise_execution_error("Client cannot process message type %c.\n"
@@ -365,7 +383,7 @@ PLy_spi_execute_plan(PyObject *ob, PyObject *list, long limit) {
 	uint32 i, j;
 	int32 nargs;
 	plcMsgSQL msg;
-	plcMsgResult *resp;
+	plcMessage *baseResp;
 	PyObject *pyresult,
 			 *pydict,
 			 *pyval;
@@ -429,11 +447,24 @@ PLy_spi_execute_plan(PyObject *ob, PyObject *list, long limit) {
 	plcontainer_channel_send(conn, (plcMessage *) &msg);
 	free_arguments(args, nargs, false, false);
 
-	resp = (plcMsgResult *) receive_from_frontend();
-	if (resp == NULL) {
-		PLy_exception_set(PLy_exc_spi_error, "Error receiving data from frontend");
+	baseResp = receive_from_frontend();
+	if (baseResp == NULL) {
+		raise_execution_error("Error receiving data from frontend");
 		return NULL;
 	}
+	if (baseResp->msgtype == MT_EXCEPTION) {
+		plcMsgError* resp = (plcMsgError *) baseResp;
+		if (resp->message != NULL) {
+			PLy_exception_set(PLy_exc_spi_error,
+					"SPI execute plan failed due to %s", resp->message);
+		} else {
+			PLy_exception_set(PLy_exc_spi_error, "SPI execute plan failed.");
+		}
+		return NULL;
+	}
+
+	assert(baseResp->msgtype == MT_RESULT);
+	plcMsgResult* resp = (plcMsgResult *) baseResp;
 
 	/*
 	 * For INSERT, UPDATE and DELETE no column will be returned,
@@ -695,7 +726,7 @@ static PyObject *
 PLy_spi_execute_query(char *query, long limit) {
 	uint32 i, j;
 	plcMsgSQL msg;
-	plcMsgResult *resp;
+	plcMessage *baseResp;
 	PyObject *pyresult,
 		*pydict,
 		*pyval;
@@ -709,12 +740,24 @@ PLy_spi_execute_query(char *query, long limit) {
 
 	plcontainer_channel_send(conn, (plcMessage *) &msg);
 
-	resp = (plcMsgResult *) receive_from_frontend();
-	if (resp == NULL) {
+	baseResp = receive_from_frontend();
+	if (baseResp == NULL) {
 		raise_execution_error("Error receiving data from frontend");
 		return NULL;
 	}
+	if(baseResp->msgtype == MT_EXCEPTION) {
+		plcMsgError* resp = (plcMsgError *) baseResp;
+		if (resp->message != NULL) {
+			PLy_exception_set(PLy_exc_spi_error,
+					"SPI execute query failed due to %s", resp->message);
+		} else {
+			PLy_exception_set(PLy_exc_spi_error, "SPI execute query failed.");
+		}
+		return NULL;
+	}
 
+	assert(baseResp->msgtype == MT_RESULT);
+	plcMsgResult* resp = (plcMsgResult *)baseResp;
 	/*
 	 * For INSERT, UPDATE and DELETE no column will be returned,
 	 * so if resp->cols > 0, it must be SELECT statment.
@@ -810,7 +853,7 @@ PyObject *PLy_spi_prepare(PyObject *self UNUSED, PyObject *args) {
 	plcMessage *resp;
 	plcConn *conn = plcconn_global;
 	char *query;
-	int nargs, res;
+	int nargs;
 	PLyPlanObject *py_plan;
 	PyObject *list = NULL;
 	PyObject *optr = NULL;
@@ -865,9 +908,19 @@ PyObject *PLy_spi_prepare(PyObject *self UNUSED, PyObject *args) {
 	plcontainer_channel_send(conn, (plcMessage *) &msg);
 	free_arguments(msg.args, msg.nargs, false, false);
 
-	res = plcontainer_channel_receive(conn, &resp, MT_RAW_BIT);
-	if (res < 0) {
-		PLy_exception_set(PLy_exc_spi_error, "Error receiving data from the frontend, %d", res);
+	resp = receive_from_frontend();
+	if (resp == NULL) {
+		raise_execution_error("Error receiving data from frontend");
+		return NULL;
+	}
+	if (resp->msgtype == MT_EXCEPTION) {
+		plcMsgError* errorResp = (plcMsgError *) resp;
+		if (errorResp->message != NULL) {
+			PLy_exception_set(PLy_exc_spi_error,
+					"SPI prepare failed due to %s", errorResp->message);
+		} else {
+			PLy_exception_set(PLy_exc_spi_error, "SPI prepare failed.");
+		}
 		return NULL;
 	}
 
@@ -938,7 +991,6 @@ PLy_exception_set(PyObject *exc, const char *fmt, ...) {
 	va_end(ap);
 
 	plc_elog(DEBUG1, "Python caught an exception: %s", buf);
-
 	PyErr_SetString(exc, buf);
 }
 

--- a/src/pyclient/pyerror.c
+++ b/src/pyclient/pyerror.c
@@ -17,6 +17,7 @@
 
 #include <Python.h>
 
+#define ERR_MSG_LENGTH 512
 static char *get_python_error();
 
 /* Stack of error messages obtained when no connectivity was available */
@@ -104,7 +105,7 @@ void raise_execution_error(const char *format, ...) {
 		int len, res;
 
 		va_start(args, format);
-		len = 100 + 2 * strlen(format);
+		len = ERR_MSG_LENGTH + 2 * strlen(format);
 		msg = (char *) malloc(len + 1);
 		res = vsnprintf(msg, len, format, args);
 		if (res < 0 || res >= len) {

--- a/src/sqlhandler.c
+++ b/src/sqlhandler.c
@@ -46,7 +46,6 @@ static plcMsgResult *create_sql_result(bool isSelect) {
 	result = palloc(sizeof(plcMsgResult));
 	result->msgtype = MT_RESULT;
 	result->rows = SPI_processed;
-
 	if (!isSelect) {
 		result->cols = 0;
 		result->types = NULL;
@@ -333,10 +332,10 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 						break;
 					default:
 						plc_elog(ERROR, "Cannot handle sql ('%s') with fn_readonly (%d) "
-									"and limit ("
-									INT64_FORMAT
-									"). Detail: %s", msg->statement,
-								     pinfo->fn_readonly, msg->limit, SPI_result_code_string(retval));
+							"and limit ("
+							INT64_FORMAT
+							"). Detail: %s", msg->statement,
+							pinfo->fn_readonly, msg->limit, SPI_result_code_string(retval));
 						break;
 				}
 				SPI_freetuptable(SPI_tuptable);
@@ -406,13 +405,32 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 	}
 	PG_CATCH();
 	{
-		/* Make sure the memroy context is in correct position */
+		ErrorData *edata;
+		/* Save error info */
 		MemoryContextSwitchTo(oldcontext);
+		edata = CopyErrorData();
+		FlushErrorState();
+
+		/* Make sure the memroy context is in correct position */
 		RollbackAndReleaseCurrentSubTransaction();
 		MemoryContextSwitchTo(oldcontext);
 		CurrentResourceOwner = oldowner;
-		
-		PG_RE_THROW();
+
+		plcMsgError *err;
+
+		/* an exception send to container side, which will be freed after send.
+		 * TODO: we treat them as general SPI error now.
+		 */
+		err = palloc(sizeof(plcMsgError));
+		err->msgtype = MT_EXCEPTION;
+		err->message = (char *) palloc(strlen(edata->message) + 1);
+		memcpy(err->message, edata->message, strlen(edata->message));
+		err->message[strlen(edata->message)] = '\0';
+		err->stacktrace = NULL;
+
+		result = (plcMessage *) err;
+		return result;
+
 	}
 	PG_END_TRY();
 

--- a/tests/expected/spi_python.out
+++ b/tests/expected/spi_python.out
@@ -304,17 +304,19 @@ NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
 (1 row)
 
 select py_spi_illegal_pexecute1();
-ERROR:  operator does not exist: bytea = integer
-LINE 1: select * from t4 where name=$1 order by score1
-                                   ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
-QUERY:  select * from t4 where name=$1 order by score1
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 5, in py_spi_illegal_pexecute1
+SPIError: SPI prepare failed due to operator does not exist: bytea = integer
 select py_spi_illegal_pexecute2();
-ERROR:  operator does not exist: real < bytea
-LINE 1: select * from t4 where score1<$1 order by score1
-                                     ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
-QUERY:  select * from t4 where score1<$1 order by score1
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 5, in py_spi_illegal_pexecute2
+SPIError: SPI prepare failed due to operator does not exist: real < bytea
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
  py_spi_simple_t4 
@@ -394,17 +396,26 @@ NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
 (1 row)
 
 select pyspi_illegal_sql();
-ERROR:  relation "pg_database_invalid" does not exist
-LINE 1: select datname from pg_database_invalid
-                            ^
-QUERY:  select datname from pg_database_invalid
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 4, in pyspi_illegal_sql
+SPIError: SPI execute query failed due to relation "pg_database_invalid" does not exist
 select pyspi_illegal_sql_pexecute();
-ERROR:  relation "pg_database_invalid" does not exist
-LINE 1: select datname from pg_database_invalid
-                            ^
-QUERY:  select datname from pg_database_invalid
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 4, in pyspi_illegal_sql_pexecute
+SPIError: SPI prepare failed due to relation "pg_database_invalid" does not exist
 select pyspi_bad_limit();
-ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (0) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 4, in pyspi_bad_limit
+SPIError: SPI execute query failed due to plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (0) and limit (-2). Detail: SPI_ERROR_ARGUMENT
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
  py_spi_simple_t4 
@@ -420,9 +431,19 @@ DETAIL:
   File "<string>", line 4, in pyspi_bad_limit_pexecute
 TypeError: second argument of plpy.prepare must be a sequence
 select pyspi_bad_limit_immutable();
-ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 4, in pyspi_bad_limit_immutable
+SPIError: SPI execute query failed due to plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT
 select pyspi_bad_limit_stable();
-ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 4, in pyspi_bad_limit_stable
+SPIError: SPI execute query failed due to plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
  py_spi_simple_t4 
@@ -723,11 +744,21 @@ except Exception, ex:
 return None
 $$ LANGUAGE plcontainer;
 SELECT invalid_type_uncaught('rick');
-ERROR:  type "test" does not exist
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Exception occurred in Python during function execution 
+ Traceback (most recent call last):
+  File "<string>", line 6, in invalid_type_uncaught
+SPIError: SPI prepare failed due to type "test" does not exist
 SELECT invalid_type_caught('rick');
-ERROR:  type "test" does not exist
+NOTICE:  SPI prepare failed due to type "test" does not exist
+ invalid_type_caught 
+---------------------
+ 
+(1 row)
+
 SELECT invalid_type_reraised('rick');
-ERROR:  type "test" does not exist
+ERROR:  SPI prepare failed due to type "test" does not exist
 SELECT valid_type('rick');
  valid_type 
 ------------
@@ -758,3 +789,58 @@ select spi_prepared_plan_test_nested('smith');
  there are 1 smiths
 (1 row)
 
+CREATE TABLE subtransaction_tbl (
+    i integer
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE FUNCTION try_catch_inside_subtransaction() RETURNS void
+AS $$
+# container: plc_python_shared
+with plpy.subtransaction():
+     plpy.execute("INSERT INTO subtransaction_tbl VALUES (1)")
+     try:
+         plpy.execute("INSERT INTO subtransaction_tbl VALUES ('a')")
+     except plpy.SPIError:
+         plpy.notice("caught")
+$$ LANGUAGE plcontainer;
+SELECT try_catch_inside_subtransaction();
+NOTICE:  caught
+ try_catch_inside_subtransaction 
+---------------------------------
+ 
+(1 row)
+
+SELECT * FROM subtransaction_tbl;
+ i 
+---
+ 1
+(1 row)
+
+TRUNCATE subtransaction_tbl;
+ALTER TABLE subtransaction_tbl ADD PRIMARY KEY (i);
+NOTICE:  ALTER TABLE / ADD PRIMARY KEY will create implicit index "subtransaction_tbl_pkey" for table "subtransaction_tbl"
+CREATE FUNCTION pk_violation_inside_subtransaction() RETURNS void
+AS $$
+# container: plc_python_shared
+with plpy.subtransaction():
+     plpy.execute("INSERT INTO subtransaction_tbl VALUES (1)")
+     try:
+         plpy.execute("INSERT INTO subtransaction_tbl VALUES (1)")
+     except plpy.SPIError:
+         plpy.notice("caught")
+$$ LANGUAGE plcontainer;
+SELECT pk_violation_inside_subtransaction();
+NOTICE:  caught
+ pk_violation_inside_subtransaction 
+------------------------------------
+ 
+(1 row)
+
+SELECT * FROM subtransaction_tbl;
+ i 
+---
+ 1
+(1 row)
+
+DROP TABLE subtransaction_tbl;

--- a/tests/expected/spi_r.out
+++ b/tests/expected/spi_r.out
@@ -297,11 +297,8 @@ NOTICE:  bob0
 (1 row)
 
 select r_spi_illegal_pexecute1();
-ERROR:  operator does not exist: bytea = integer
-LINE 1: select * from t4r where name=$1 order by score1
-                                    ^
-HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
-QUERY:  select * from t4r where name=$1 order by score1
+ERROR:  PL/Container client exception occurred:
+DETAIL:  SPI process_SPI_results failed due to operator does not exist: bytea = integer
 select r_spi_illegal_pexecute2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  
@@ -350,15 +347,11 @@ NOTICE:  bob0
 (1 row)
 
 select rspi_illegal_sql();
-ERROR:  relation "pg_database_invalid" does not exist
-LINE 1: select datname from pg_database_invalid
-                            ^
-QUERY:  select datname from pg_database_invalid
+ERROR:  PL/Container client exception occurred:
+DETAIL:  SPI process_SPI_results failed due to relation "pg_database_invalid" does not exist
 select rspi_illegal_sql_pexecute();
-ERROR:  relation "pg_database_invalid" does not exist
-LINE 1: select datname from pg_database_invalid
-                            ^
-QUERY:  select datname from pg_database_invalid
+ERROR:  PL/Container client exception occurred:
+DETAIL:  SPI process_SPI_results failed due to relation "pg_database_invalid" does not exist
 select r_spi_simple_t4();
 NOTICE:  bob0
  r_spi_simple_t4 

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -449,8 +449,7 @@ NOTICE:  this is the notice message
 CONTEXT:  SQL statement "select pylogging()"
 WARNING:  this is the warning message
 CONTEXT:  SQL statement "select pylogging()"
-ERROR:  this is the error message
-CONTEXT:  SQL statement "select pylogging()"
+ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:361)
 select pygdset('1','a');
  pygdset 
 ---------

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -449,8 +449,7 @@ NOTICE:  this is the notice message
 CONTEXT:  SQL statement "select pylogging()"
 WARNING:  this is the warning message
 CONTEXT:  SQL statement "select pylogging()"
-ERROR:  this is the error message
-CONTEXT:  SQL statement "select pylogging()"
+ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:361)
 select pygdset('1','a');
  pygdset 
 ---------

--- a/tests/expected/test_r.out
+++ b/tests/expected/test_r.out
@@ -361,7 +361,14 @@ INFO:  this is the info message
 NOTICE:  this is the notice message
 WARNING:  this is the warning message
 ERROR:  this is the error message
---select rlogging2();
+select rlogging2();
+INFO:  this is the info message
+CONTEXT:  SQL statement "select rlogging()"
+NOTICE:  this is the notice message
+CONTEXT:  SQL statement "select rlogging()"
+WARNING:  this is the warning message
+CONTEXT:  SQL statement "select rlogging()"
+ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:390)
 \! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
 FATAL:  this is the fatal message
 server closed the connection unexpectedly
@@ -544,8 +551,18 @@ select rnested_call_three('foo');
  foo
 (1 row)
 
---select rnested_call_two('foobar');
---select rnested_call_one('foo1');
+select rnested_call_two('foobar');
+ rnested_call_two 
+------------------
+ foobar
+(1 row)
+
+select rnested_call_one('foo1');
+ rnested_call_one 
+------------------
+ foo1
+(1 row)
+
 select rtestudt1( ('t', 1, 2, 3, 4, 5, 6, 'foobar')::test_type );
  rtestudt1 
 -----------

--- a/tests/expected/test_r.out
+++ b/tests/expected/test_r.out
@@ -361,15 +361,7 @@ INFO:  this is the info message
 NOTICE:  this is the notice message
 WARNING:  this is the warning message
 ERROR:  this is the error message
-select rlogging2();
-INFO:  this is the info message
-CONTEXT:  SQL statement "select rlogging()"
-NOTICE:  this is the notice message
-CONTEXT:  SQL statement "select rlogging()"
-WARNING:  this is the warning message
-CONTEXT:  SQL statement "select rlogging()"
-ERROR:  this is the error message
-CONTEXT:  SQL statement "select rlogging()"
+--select rlogging2();
 \! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
 FATAL:  this is the fatal message
 server closed the connection unexpectedly
@@ -552,18 +544,8 @@ select rnested_call_three('foo');
  foo
 (1 row)
 
-select rnested_call_two('foobar');
- rnested_call_two 
-------------------
- foobar
-(1 row)
-
-select rnested_call_one('foo1');
- rnested_call_one 
-------------------
- foo1
-(1 row)
-
+--select rnested_call_two('foobar');
+--select rnested_call_one('foo1');
 select rtestudt1( ('t', 1, 2, 3, 4, 5, 6, 'foobar')::test_type );
  rtestudt1 
 -----------

--- a/tests/expected/test_r_error.out
+++ b/tests/expected/test_r_error.out
@@ -63,10 +63,8 @@ DETAIL:
  Error in (rerror_non_exist_function <- function(args) { : 
   could not find function "as.mx"
 select rerror_spi_queryfail(); 
-ERROR:  relation "non_exist_table" does not exist
-LINE 1: select fname from non_exist_table order by 1
-                          ^
-QUERY:  select fname from non_exist_table order by 1
+ERROR:  PL/Container client exception occurred:
+DETAIL:  SPI process_SPI_results failed due to relation "non_exist_table" does not exist
 select rerror_setof();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Error in array(1:3, c(-1, 2)) : negative length vectors are not allowed

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -2,14 +2,49 @@
 test: schema
 
 # Test plcontainer utility.
+test: test_utility
 
 # configuration function tests
+test: test_configuration
 
 # test declaration combinations in function definitions.
+test: runtimeid_declaration
 
 # set R and Python function - need before "test PL/Container normal function"
 test: function_r function_r_gpdb5 function_python function_python_gpdb5
 
 # test PL/Container normal function
-test: spi_python 
+test: test_r 
 test: test_python
+test: test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
+test: test_r_error test_python_error 
+test: exception
+test: faultinject_python
+
+# test wrong configuration validation in pl/container C code
+test: test_wrong_config
+# PL/Container UDA test
+test: uda_python uda_r
+
+# Out of memory test
+test: oom_test_prepare_pyhthon
+test: oom_test_python_killed oom_test_python_killed_1 oom_test_python_normal oom_test_python_normal_1 oom_test_python_normal_2
+
+# Miscellaneous test
+test: misc
+test: user_control
+
+# PL/Container parallel test (io & cpu)
+test: parallel_prepare
+test: parallel_1 parallel_2 parallel_3 parallel_4 parallel_5 parallel_6 parallel_7 parallel_8
+
+# PL/Container memory test
+test: memory_consuming_python memory_consuming_r
+test: memory_parallel_python memory_parallel_r
+test: memory_parallel_python_1 memory_parallel_python_2 memory_parallel_python_3 memory_parallel_python_4 memory_parallel_python_5 memory_parallel_r_1 memory_parallel_r_2 memory_parallel_r_3 memory_parallel_r_4 memory_parallel_r_5
+
+# PL/Container import pkg test
+test: python_import_module r_import_library
+
+# Drop the extension - need to be last
+test: drop

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -2,49 +2,14 @@
 test: schema
 
 # Test plcontainer utility.
-test: test_utility
 
 # configuration function tests
-test: test_configuration
 
 # test declaration combinations in function definitions.
-test: runtimeid_declaration
 
 # set R and Python function - need before "test PL/Container normal function"
 test: function_r function_r_gpdb5 function_python function_python_gpdb5
 
 # test PL/Container normal function
-test: test_r 
+test: spi_python 
 test: test_python
-test: test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
-test: test_r_error test_python_error 
-test: exception
-test: faultinject_python
-
-# test wrong configuration validation in pl/container C code
-test: test_wrong_config
-# PL/Container UDA test
-test: uda_python uda_r
-
-# Out of memory test
-test: oom_test_prepare_pyhthon
-test: oom_test_python_killed oom_test_python_killed_1 oom_test_python_normal oom_test_python_normal_1 oom_test_python_normal_2
-
-# Miscellaneous test
-test: misc
-test: user_control
-
-# PL/Container parallel test (io & cpu)
-test: parallel_prepare
-test: parallel_1 parallel_2 parallel_3 parallel_4 parallel_5 parallel_6 parallel_7 parallel_8
-
-# PL/Container memory test
-test: memory_consuming_python memory_consuming_r
-test: memory_parallel_python memory_parallel_r
-test: memory_parallel_python_1 memory_parallel_python_2 memory_parallel_python_3 memory_parallel_python_4 memory_parallel_python_5 memory_parallel_r_1 memory_parallel_r_2 memory_parallel_r_3 memory_parallel_r_4 memory_parallel_r_5
-
-# PL/Container import pkg test
-test: python_import_module r_import_library
-
-# Drop the extension - need to be last
-test: drop

--- a/tests/sql/test_r.sql
+++ b/tests/sql/test_r.sql
@@ -71,7 +71,7 @@ select rtimestamparr($${'2012-01-02 12:34:56.789012','2012-01-03 12:34:56.789012
 select rpg_spi_exec('select 1');
 
 select rlogging();
-select rlogging2();
+--select rlogging2();
 \! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
 
 select rsetofint4();
@@ -92,8 +92,8 @@ select runargs3(123, 'foo', 'bar');
 select runargs4(1,null,null,1);
 
 select rnested_call_three('foo');
-select rnested_call_two('foobar');
-select rnested_call_one('foo1');
+--select rnested_call_two('foobar');
+--select rnested_call_one('foo1');
 select rtestudt1( ('t', 1, 2, 3, 4, 5, 6, 'foobar')::test_type );
 select rtestudt2( (
         array[true,false,true]::bool[],

--- a/tests/sql/test_r.sql
+++ b/tests/sql/test_r.sql
@@ -71,7 +71,7 @@ select rtimestamparr($${'2012-01-02 12:34:56.789012','2012-01-03 12:34:56.789012
 select rpg_spi_exec('select 1');
 
 select rlogging();
---select rlogging2();
+select rlogging2();
 \! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
 
 select rsetofint4();
@@ -92,8 +92,8 @@ select runargs3(123, 'foo', 'bar');
 select runargs4(1,null,null,1);
 
 select rnested_call_three('foo');
---select rnested_call_two('foobar');
---select rnested_call_one('foo1');
+select rnested_call_two('foobar');
+select rnested_call_one('foo1');
 select rtestudt1( ('t', 1, 2, 3, 4, 5, 6, 'foobar')::test_type );
 select rtestudt2( (
         array[true,false,true]::bool[],


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
plpy execute or prepare may encounter error, but these errors maybe catched/ignored at container side, so we need to pass the plpy error to container side.
## Tests
<!-- describe your test -->

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
#418 