### PR TITLE
Disallow pseudotype result, except for void or record

### DIFF
--- a/src/message_fns.c
+++ b/src/message_fns.c
@@ -132,6 +132,29 @@ plcProcInfo *plcontainer_procedure_get(FunctionCallInfo fcinfo) {
 
 		proc->hasChanged = 1;
 
+		HeapTuple rvTypeTup;
+		Form_pg_type rvTypeStruct;
+
+		rvTypeTup = SearchSysCache1(TYPEOID,
+				ObjectIdGetDatum(procStruct->prorettype));
+		if (!HeapTupleIsValid(rvTypeTup))
+			elog(ERROR, "cache lookup failed for type %u",
+					procStruct->prorettype);
+		rvTypeStruct = (Form_pg_type) GETSTRUCT(rvTypeTup);
+
+		/* Disallow pseudotype result, except for void or record */
+		if (rvTypeStruct->typtype == TYPTYPE_PSEUDO) {
+			if (procStruct->prorettype == TRIGGEROID)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg(
+								"trigger functions can only be called as triggers")));
+			else if (procStruct->prorettype != VOIDOID
+					&& procStruct->prorettype != RECORDOID)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg(
+								"PLContainer functions cannot return type %s",
+								format_type_be(procStruct->prorettype))));
+		}
 		procStruct = (Form_pg_proc) GETSTRUCT(procHeapTup);
 		fill_type_info(fcinfo, procStruct->prorettype, &proc->result);
 

--- a/tests/expected/function_python.out
+++ b/tests/expected/function_python.out
@@ -572,3 +572,7 @@ def fun3():
 fun3()
 return "not reached"
 $$ LANGUAGE plcontainer;
+create function pseudotype_result(anyelement) returns anyarray as $$
+# container: plc_python_shared
+pass;
+$$ language plcontainer;

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -727,6 +727,8 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Fatal: boom
+select pseudotype_result(1);
+ERROR:  PLContainer functions cannot return type anyarray
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -727,6 +727,8 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Fatal: boom
+select pseudotype_result(1);
+ERROR:  PLContainer functions cannot return type anyarray
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
 server closed the connection unexpectedly

--- a/tests/sql/function_python.sql
+++ b/tests/sql/function_python.sql
@@ -667,3 +667,8 @@ def fun3():
 fun3()
 return "not reached"
 $$ LANGUAGE plcontainer;
+
+create function pseudotype_result(anyelement) returns anyarray as $$
+# container: plc_python_shared
+pass;
+$$ language plcontainer;

--- a/tests/sql/test_python.sql
+++ b/tests/sql/test_python.sql
@@ -122,4 +122,5 @@ select multiout_simple_setof();
 SELECT nnint_test(null, 3);
 select nested_error_raise();
 select nested_fatal_raise();
+select pseudotype_result(1);
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"


### PR DESCRIPTION
## Description
Disallow pseudotype result, except for void or record
This logic come from plpython.

## Tests

## Additional Notes

## User Story or Issue
