### PR TITLE
cache pg_type leakage fixed

### DIFF
--- a/src/message_fns.c
+++ b/src/message_fns.c
@@ -155,6 +155,7 @@ plcProcInfo *plcontainer_procedure_get(FunctionCallInfo fcinfo) {
 								"PLContainer functions cannot return type %s",
 								format_type_be(procStruct->prorettype))));
 		}
+		ReleaseSysCache(rvTypeTup);
 		procStruct = (Form_pg_proc) GETSTRUCT(procHeapTup);
 
 		fill_type_info(fcinfo, procStruct->prorettype, &proc->result);


### PR DESCRIPTION
## Description
Cache pg_type is not relaeased. Fix it
This was due to to pr https://github.com/greenplum-db/plcontainer/pull/437

## Tests
No test needed

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
