### PR TITLE
Since type conversion function is recursive, it could theoretically b…

### DIFF
--- a/src/plc_typeio.c
+++ b/src/plc_typeio.c
@@ -103,6 +103,9 @@ fill_type_info_inner(FunctionCallInfo fcinfo, Oid typeOid, plcTypeInfo *type, bo
 	char dummy_delim;
 	Oid typioparam;
 
+	/* Since this is recursive, it could theoretically be driven to overflow */
+	check_stack_depth();
+
 	if (get_typtype(typeOid) == TYPTYPE_DOMAIN) {
 		plc_elog(ERROR, "plcontainer does not support domain type");
 	}

--- a/tests/init_file
+++ b/tests/init_file
@@ -29,4 +29,6 @@ m/plc_configuration.c:\d+\)/
 s/plc_configuration.c:\d+\)/plc_configuration.c:xxx/
 m/sqlhandler.c:\d+\)/
 s/sqlhandler.c:\d+\)/sqlhandler.c:xxx/
+m/plc_typeio.c:\d+\)/
+s/plc_typeio.c:\d+\)/plc_typeio.c:xxx/
 -- end_matchsubs


### PR DESCRIPTION
## Description
Since type conversion function is recursive, it could theoretically be driven to overflow
Add check stack depth for it

## Tests
Just theoretically to overflow, could not construct such stable test

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
