### PR TITLE
Support escaping strings functions in plpy module

### DIFF
--- a/src/common/messages/message_quote.h
+++ b/src/common/messages/message_quote.h
@@ -1,0 +1,31 @@
+/*------------------------------------------------------------------------------
+ *
+ *
+ * Copyright (c) 2016-Present Pivotal Software, Inc
+ *
+ *------------------------------------------------------------------------------
+ */
+#ifndef PLC_MESSAGE_QUOTE_H
+#define PLC_MESSAGE_QUOTE_H
+
+#include "message_base.h"
+
+typedef enum {
+	QUOTE_TYPE_LITERAL = 0,
+	QUOTE_TYPE_NULLABLE,
+	QUOTE_TYPE_IDENT
+} plcQuoteType;
+
+typedef struct plcMsgQuote {
+	base_message_content;
+	plcQuoteType quote_type;
+	char * msg;
+} plcMsgQuote;
+
+typedef struct plcMsgQuoteResult {
+	base_message_content;
+	plcQuoteType quote_type;
+	char *result;
+} plcMsgQuoteResult;
+
+#endif /* PLC_MESSAGE_QUOTE_H */

--- a/src/common/messages/message_types.h
+++ b/src/common/messages/message_types.h
@@ -11,6 +11,8 @@
 #define MT_CALLREQ        'C'
 #define MT_EXCEPTION      'E'
 #define MT_LOG            'L'
+#define MT_QUOTE          'Q'
+#define MT_QUOTE_RESULT   'O'
 #define MT_PING           'P'
 #define MT_RESULT         'R'
 #define MT_SQL            'S'
@@ -35,6 +37,8 @@
 #define MT_SUBTRANSACTION_BIT 0x400LL
 #define MT_SUBTRAN_RESULT_BIT 0x800LL
 #define MT_EOF_BIT            0x1000LL
+#define MT_QUOTE_BIT          0x2000LL
+#define MT_QUOTE_RESULT_BIT   0x4000LL
 
 #define MT_ALL_BITS        0xFFFFffffFFFFffffLL
 

--- a/src/common/messages/messages.h
+++ b/src/common/messages/messages.h
@@ -19,5 +19,6 @@
 #include "message_data.h"
 #include "message_ping.h"
 #include "message_subtransaction.h"
+#include "message_quote.h"
 
 #endif /* PLC_MESSAGES_H */

--- a/src/pyclient/pycall.c
+++ b/src/pyclient/pycall.c
@@ -16,6 +16,7 @@
 #include "pyerror.h"
 #include "pyconversions.h"
 #include "pylogging.h"
+#include "pyquote.h"
 #include "plpy_spi.h"
 #include "pycache.h"
 
@@ -53,6 +54,13 @@ static PyMethodDef moddef[] = {
 	 * execute a plan or query
 	 */
 	{"execute",        PLy_spi_execute,    METH_VARARGS, NULL},
+
+	/*
+	 * escaping strings
+	 */
+	{"quote_literal", PLy_quote_literal, METH_VARARGS, NULL },
+	{"quote_nullable", PLy_quote_nullable, METH_VARARGS, NULL },
+	{"quote_ident", PLy_quote_ident, METH_VARARGS, NULL },
 
 	/*
 	 * create the subtransaction context manager

--- a/src/pyclient/pyquote.c
+++ b/src/pyclient/pyquote.c
@@ -1,0 +1,99 @@
+/*------------------------------------------------------------------------------
+ *
+ *
+ * Copyright (c) 2016-Present Pivotal Software, Inc
+ *
+ *------------------------------------------------------------------------------
+ */
+
+#include "pycall.h"
+#include "pyquote.h"
+#include "common/messages/messages.h"
+#include "common/comm_channel.h"
+#include "common/comm_utils.h"
+
+#include <Python.h>
+
+PyObject *
+PLy_quote_literal(PyObject *self UNUSED, PyObject *args)
+{
+	plcConn *conn = plcconn_global;
+	plcMsgQuote *msg;
+	plcMessage *resp = NULL;
+	const char *str;
+	char	   *quoted;
+	PyObject   *ret;
+
+	if (!PyArg_ParseTuple(args, "s", &str))
+		return NULL;
+
+	msg = pmalloc(sizeof(plcMsgQuote));
+	msg->msgtype = MT_QUOTE;
+	msg->quote_type = QUOTE_TYPE_LITERAL;
+	msg->msg = strdup(str);
+	plcontainer_channel_send(conn, (plcMessage *) msg);
+	plcontainer_channel_receive(conn, &resp, MT_QUOTE_RESULT_BIT);
+	quoted = strdup(((plcMsgQuoteResult *)resp)->result);
+	ret = PyString_FromString(quoted);
+	pfree(quoted);
+
+	return ret;
+}
+
+PyObject *
+PLy_quote_nullable(PyObject *self UNUSED, PyObject *args)
+{
+	plcConn *conn = plcconn_global;
+	plcMsgQuote *msg;
+	plcMessage *resp = NULL;
+	const char *str;
+	char	   *quoted;
+	PyObject   *ret;
+
+	if (!PyArg_ParseTuple(args, "z", &str))
+		return NULL;
+
+	if (str == NULL)
+		return PyString_FromString("NULL");
+
+	msg = pmalloc(sizeof(plcMsgQuote));
+	msg->msgtype = MT_QUOTE;
+	msg->quote_type = QUOTE_TYPE_NULLABLE;
+	msg->msg = strdup(str);
+	plcontainer_channel_send(conn, (plcMessage *) msg);
+	plcontainer_channel_receive(conn, &resp, MT_QUOTE_RESULT_BIT);
+	quoted = strdup(((plcMsgQuoteResult *)resp)->result);
+	ret = PyString_FromString(quoted);
+	pfree(quoted);
+
+	return ret;
+}
+
+PyObject *
+PLy_quote_ident(PyObject *self UNUSED, PyObject *args)
+{
+	plc_elog(LOG, "Client has step into quote_ident");
+	plcConn *conn = plcconn_global;
+	plcMsgQuote *msg;
+	plcMessage *resp = NULL;
+	const char *str;
+	char *quoted;
+	PyObject   *ret;
+
+	if (!PyArg_ParseTuple(args, "s", &str))
+		return NULL;
+
+	msg = pmalloc(sizeof(plcMsgQuote));
+	msg->msgtype = MT_QUOTE;
+	msg->quote_type = QUOTE_TYPE_IDENT;
+	msg->msg = strdup(str);
+	plc_elog(LOG, "Client has step before plcontainer_channel_send");
+	plcontainer_channel_send(conn, (plcMessage *) msg);
+	plc_elog(LOG, "Client has step before plcontainer_channel_receive");
+	plcontainer_channel_receive(conn, &resp, MT_QUOTE_RESULT_BIT);
+	quoted = strdup(((plcMsgQuoteResult *)resp)->result);
+	ret = PyString_FromString(quoted);
+	pfree(quoted);
+
+	return ret;
+}

--- a/src/pyclient/pyquote.h
+++ b/src/pyclient/pyquote.h
@@ -1,0 +1,20 @@
+/*------------------------------------------------------------------------------
+ *
+ *
+ * Copyright (c) 2018-Present Pivotal Software, Inc
+ *
+ *------------------------------------------------------------------------------
+ */
+
+#ifndef PLC_PYQUOTE_H
+#define PLC_PYQUOTE_H
+
+#include <Python.h>
+
+PyObject * PLy_quote_literal(PyObject *self, PyObject *args);
+
+PyObject * PLy_quote_nullable(PyObject *self, PyObject *args);
+
+PyObject * PLy_quote_ident(PyObject *self, PyObject *args);
+
+#endif /* PLC_PYQUOTE_H */

--- a/tests/expected/plpython_quote.out
+++ b/tests/expected/plpython_quote.out
@@ -1,0 +1,56 @@
+CREATE FUNCTION quote(t text, how text) RETURNS text AS $$
+# container: plc_python_shared
+    if how == "literal":
+        return plpy.quote_literal(t)
+    elif how == "nullable":
+        return plpy.quote_nullable(t)
+    elif how == "ident":
+        return plpy.quote_ident(t)
+    else:
+        raise plpy.Error("unrecognized quote type %s" % how)
+$$ LANGUAGE plcontainer;
+SELECT quote(t, 'literal') FROM (VALUES
+       ('abc'),
+       ('a''bc'),
+       ('''abc'''),
+       (''),
+       (''''),
+       ('xyzv')) AS v(t);
+   quote   
+-----------
+ 'abc'
+ 'a''bc'
+ '''abc'''
+ ''
+ ''''
+ 'xyzv'
+(6 rows)
+
+SELECT quote(t, 'nullable') FROM (VALUES
+       ('abc'),
+       ('a''bc'),
+       ('''abc'''),
+       (''),
+       (''''),
+       (NULL)) AS v(t);
+   quote   
+-----------
+ 'abc'
+ 'a''bc'
+ '''abc'''
+ ''
+ ''''
+ NULL
+(6 rows)
+
+SELECT quote(t, 'ident') FROM (VALUES
+       ('abc'),
+       ('a b c'),
+       ('a " ''abc''')) AS v(t);
+    quote     
+--------------
+ abc
+ "a b c"
+ "a "" 'abc'"
+(3 rows)
+

--- a/tests/pl_schedule
+++ b/tests/pl_schedule
@@ -16,6 +16,7 @@ test: function_r function_r_gpdb5 function_python function_python_gpdb5
 # test PL/Container normal function
 test: test_r 
 test: test_python
+test: plpython_quote
 test: test_r_gpdb5 test_python_gpdb5 spi_r spi_python subtransaction_python
 test: test_r_error test_python_error 
 test: exception

--- a/tests/sql/plpython_quote.sql
+++ b/tests/sql/plpython_quote.sql
@@ -1,0 +1,33 @@
+CREATE FUNCTION quote(t text, how text) RETURNS text AS $$
+# container: plc_python_shared
+    if how == "literal":
+        return plpy.quote_literal(t)
+    elif how == "nullable":
+        return plpy.quote_nullable(t)
+    elif how == "ident":
+        return plpy.quote_ident(t)
+    else:
+        raise plpy.Error("unrecognized quote type %s" % how)
+$$ LANGUAGE plcontainer;
+
+SELECT quote(t, 'literal') FROM (VALUES
+       ('abc'),
+       ('a''bc'),
+       ('''abc'''),
+       (''),
+       (''''),
+       ('xyzv')) AS v(t);
+
+SELECT quote(t, 'nullable') FROM (VALUES
+       ('abc'),
+       ('a''bc'),
+       ('''abc'''),
+       (''),
+       (''''),
+       (NULL)) AS v(t);
+
+SELECT quote(t, 'ident') FROM (VALUES
+       ('abc'),
+       ('a b c'),
+       ('a " ''abc''')) AS v(t);
+


### PR DESCRIPTION
Support escaping strings functions in plpy module by following python function: 
plpy.quote_literal
plpy.quote_nullable
plpy.quote_ident

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Tests
```
CREATE FUNCTION quote(t text, how text) RETURNS text AS $$
# container: plc_python_shared
    if how == "literal":
        return plpy.quote_literal(t)
    elif how == "nullable":
        return plpy.quote_nullable(t)
    elif how == "ident":
        return plpy.quote_ident(t)
    else:
        raise plpy.Error("unrecognized quote type %s" % how)
$$ LANGUAGE plcontainer;

SELECT quote(t, 'literal') FROM (VALUES
       ('abc'),
       ('a''bc'),
       ('''abc'''),
       (''),
       (''''),
       ('xyzv')) AS v(t);

SELECT quote(t, 'nullable') FROM (VALUES
       ('abc'),
       ('a''bc'),
       ('''abc'''),
       (''),
       (''''),
       (NULL)) AS v(t);

SELECT quote(t, 'ident') FROM (VALUES
       ('abc'),
       ('a b c'),
       ('a " ''abc''')) AS v(t);

```

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
