### PR TITLE
Support error context stack

### DIFF
--- a/tests/expected/oom_test_python_killed.out
+++ b/tests/expected/oom_test_python_killed.out
@@ -6,7 +6,10 @@ select py_memory_allocate_oom(1);
 (1 row)
 
 select py_memory_allocate_oom(512);
+WARNING:  plcontainer: docker reports container has been terminated due to out of memory. This could be either the container was over memory limit or inside program crashed
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 ERROR:  plcontainer: Error receiving data from the client. Maybe retry later. (plcontainer.c:255)
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 select py_memory_allocate_oom(1);
  py_memory_allocate_oom 
 ------------------------
@@ -20,7 +23,10 @@ select py_memory_allocate_normal(512);
 (1 row)
 
 select py_memory_allocate_oom(512);
+WARNING:  plcontainer: docker reports container has been terminated due to out of memory. This could be either the container was over memory limit or inside program crashed
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 ERROR:  plcontainer: Error receiving data from the client. Maybe retry later. (plcontainer.c:255)
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 select py_memory_allocate_normal(512);
  py_memory_allocate_normal 
 ---------------------------
@@ -35,7 +41,10 @@ select count(py_memory_allocate_oom(num)) from OOM_TEST;
 (1 row)
 
 select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+WARNING:  plcontainer: docker reports container has been terminated due to out of memory. This could be either the container was over memory limit or inside program crashed  (seg1 slice1 192.168.4.25:20001 pid=13585)
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 ERROR:  plcontainer: Error receiving data from the client. Maybe retry later. (plcontainer.c:255)  (seg1 slice1 127.0.0.1:25433 pid=26450) (plcontainer.c:255)
+DETAIL:  PLContainer function "py_memory_allocate_oom"
 select count(py_memory_allocate_oom(num)) from OOM_TEST;
  count 
 -------
@@ -49,7 +58,10 @@ select count(py_memory_allocate_normal(aux)) from OOM_TEST;
 (1 row)
 
 select count(py_memory_allocate_oom(aux)) from OOM_TEST;
+WARNING:  plcontainer: docker reports container has been terminated due to out of memory. This could be either the container was over memory limit or inside program crashed  (seg1 slice1 192.168.4.25:20001 pid=13585)
+CONTEXT:  PLContainer function "py_memory_allocate_oom"
 ERROR:  plcontainer: Error receiving data from the client. Maybe retry later. (plcontainer.c:255)  (seg0 slice1 127.0.0.1:25432 pid=26449) (plcontainer.c:255)
+DETAIL:  PLContainer function "py_memory_allocate_oom"
 select count(py_memory_allocate_normal(aux)) from OOM_TEST;
  count 
 -------

--- a/tests/expected/test_python.out.gp5
+++ b/tests/expected/test_python.out.gp5
@@ -30,6 +30,7 @@ DETAIL:
  Traceback (most recent call last):
   File "<string>", line 4, in pyint
 TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
+CONTEXT:  PLContainer function "pyint"
 select pyint(123::int2);
  pyint 
 -------
@@ -439,17 +440,28 @@ select py_plpy_get_record();
 
 select pylogging();
 INFO:  this is the info message
+CONTEXT:  PLContainer function "pylogging"
 NOTICE:  this is the notice message
+CONTEXT:  PLContainer function "pylogging"
 WARNING:  this is the warning message
+CONTEXT:  PLContainer function "pylogging"
 ERROR:  this is the error message
+CONTEXT:  PLContainer function "pylogging"
 select pylogging2();
 INFO:  this is the info message
-CONTEXT:  SQL statement "select pylogging()"
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
 NOTICE:  this is the notice message
-CONTEXT:  SQL statement "select pylogging()"
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
 WARNING:  this is the warning message
-CONTEXT:  SQL statement "select pylogging()"
-ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:361)
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
+ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:537)
+CONTEXT:  PLContainer function "pylogging2"
 select pygdset('1','a');
  pygdset 
 ---------
@@ -492,6 +504,7 @@ select pygdgetall();
 
 select pysdset('a','000');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -499,7 +512,9 @@ INFO:  SD a -> 000
 
 select pysdset('b','111');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -507,8 +522,11 @@ INFO:  SD b -> 111
 
 select pysdset('c','222');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD c -> 222
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -521,9 +539,13 @@ select pysdgetall();
 
 select pysdset('d','333');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD c -> 222
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD d -> 333
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -631,6 +653,7 @@ select * from pytestudt13( (1,2,'a')::test_type3 );
 select pytestudt16();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Only 'dict' object can be converted to UDT "test_type3"
+CONTEXT:  PLContainer function "pytestudt16"
 select * from pytestudtrecord1() as t(a int, b int, c varchar);
  a | b |  c  
 ---+---+-----
@@ -658,21 +681,27 @@ select pyreturnsetofint8(2), pyreturnsetofint8(3);
 select pybadint();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to int4
+CONTEXT:  PLContainer function "pybadint"
 select pybadfloat8();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float4
+CONTEXT:  PLContainer function "pybadfloat8"
 select pybadudt();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Cannot find key 'c' in result dictionary for converting it into UDT
+CONTEXT:  PLContainer function "pybadudt"
 select pybadudt2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float8
+CONTEXT:  PLContainer function "pybadudt2"
 select pybadarr();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to int4
+CONTEXT:  PLContainer function "pybadarr"
 select pybadarr2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Cannot convert non-sequence object to array
+CONTEXT:  PLContainer function "pybadarr2"
 select pyinvalid_function();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  
@@ -680,6 +709,7 @@ DETAIL:
  Traceback (most recent call last):
   File "<string>", line 5, in pyinvalid_function
 AttributeError: 'module' object has no attribute 'foobar'
+CONTEXT:  PLContainer function "pyinvalid_function"
 select pysubtransaction('t');
  pysubtransaction 
 ------------------
@@ -716,6 +746,7 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Error: boom
+CONTEXT:  PLContainer function "nested_error_raise"
 select nested_fatal_raise();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  
@@ -726,10 +757,12 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Fatal: boom
+CONTEXT:  PLContainer function "nested_fatal_raise"
 select pseudotype_result(1);
 ERROR:  PLContainer functions cannot return type anyarray
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
+CONTEXT:  PLContainer function "pythonlogging_fatal"
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/tests/expected/test_python.out.gp6
+++ b/tests/expected/test_python.out.gp6
@@ -30,6 +30,7 @@ DETAIL:
  Traceback (most recent call last):
   File "<string>", line 4, in pyint
 TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
+CONTEXT:  PLContainer function "pyint"
 select pyint(123::int2);
  pyint 
 -------
@@ -439,17 +440,28 @@ select py_plpy_get_record();
 
 select pylogging();
 INFO:  this is the info message
+CONTEXT:  PLContainer function "pylogging"
 NOTICE:  this is the notice message
+CONTEXT:  PLContainer function "pylogging"
 WARNING:  this is the warning message
+CONTEXT:  PLContainer function "pylogging"
 ERROR:  this is the error message
+CONTEXT:  PLContainer function "pylogging"
 select pylogging2();
 INFO:  this is the info message
-CONTEXT:  SQL statement "select pylogging()"
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
 NOTICE:  this is the notice message
-CONTEXT:  SQL statement "select pylogging()"
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
 WARNING:  this is the warning message
-CONTEXT:  SQL statement "select pylogging()"
+CONTEXT:  PLContainer function "pylogging"
+SQL statement "select pylogging()"
+PLContainer function "pylogging"
 ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:361)
+CONTEXT:  PLContainer function "pylogging2"
 select pygdset('1','a');
  pygdset 
 ---------
@@ -499,7 +511,9 @@ INFO:  SD a -> 000
 
 select pysdset('b','111');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -507,8 +521,11 @@ INFO:  SD b -> 111
 
 select pysdset('c','222');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD c -> 222
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -521,9 +538,13 @@ select pysdgetall();
 
 select pysdset('d','333');
 INFO:  SD a -> 000
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD b -> 111
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD c -> 222
+CONTEXT:  PLContainer function "pysdset"
 INFO:  SD d -> 333
+CONTEXT:  PLContainer function "pysdset"
  pysdset 
 ---------
  ok
@@ -631,6 +652,7 @@ select * from pytestudt13( (1,2,'a')::test_type3 );
 select pytestudt16();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Only 'dict' object can be converted to UDT "test_type3"
+CONTEXT:  PLContainer function "pytestudt16"
 select * from pytestudtrecord1() as t(a int, b int, c varchar);
  a | b |  c  
 ---+---+-----
@@ -658,21 +680,27 @@ select pyreturnsetofint8(2), pyreturnsetofint8(3);
 select pybadint();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to int4
+CONTEXT:  PLContainer function "pybadint"
 select pybadfloat8();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float4
+CONTEXT:  PLContainer function "pybadfloat8"
 select pybadudt();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Cannot find key 'c' in result dictionary for converting it into UDT
+CONTEXT:  PLContainer function "pybadudt"
 select pybadudt2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float8
+CONTEXT:  PLContainer function "pybadudt2"
 select pybadarr();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to int4
+CONTEXT:  PLContainer function "pybadarr"
 select pybadarr2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Cannot convert non-sequence object to array
+CONTEXT:  PLContainer function "pybadarr2"
 select pyinvalid_function();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  
@@ -680,6 +708,7 @@ DETAIL:
  Traceback (most recent call last):
   File "<string>", line 5, in pyinvalid_function
 AttributeError: 'module' object has no attribute 'foobar'
+CONTEXT:  PLContainer function "pyinvalid_function"
 select pysubtransaction('t');
  pysubtransaction 
 ------------------
@@ -716,6 +745,7 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Error: boom
+CONTEXT:  PLContainer function "nested_error_raise"
 select nested_fatal_raise();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  
@@ -726,10 +756,12 @@ DETAIL:
   File "<string>", line 8, in fun2
   File "<string>", line 5, in fun1
 Fatal: boom
+CONTEXT:  PLContainer function "nested_fatal_raise"
 select pseudotype_result(1);
 ERROR:  PLContainer functions cannot return type anyarray
 \! psql -d ${PL_TESTDB} -c "select pythonlogging_fatal();"
 FATAL:  test plpy fatal
+CONTEXT:  PLContainer function "pythonlogging_fatal"
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.

--- a/tests/expected/test_r.out
+++ b/tests/expected/test_r.out
@@ -7,6 +7,7 @@ rshouldnotparse <- function(args) {
 # container: plc_r_shared
 return 'hello'
 }
+CONTEXT:  PLContainer function "rshouldnotparse"
 select rlog100();
  rlog100 
 ---------
@@ -358,19 +359,31 @@ select rpg_spi_exec('select 1');
 
 select rlogging();
 INFO:  this is the info message
+CONTEXT:  PLContainer function "rlogging"
 NOTICE:  this is the notice message
+CONTEXT:  PLContainer function "rlogging"
 WARNING:  this is the warning message
+CONTEXT:  PLContainer function "rlogging"
 ERROR:  this is the error message
+CONTEXT:  PLContainer function "rlogging"
 select rlogging2();
 INFO:  this is the info message
-CONTEXT:  SQL statement "select rlogging()"
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
 NOTICE:  this is the notice message
-CONTEXT:  SQL statement "select rlogging()"
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
 WARNING:  this is the warning message
-CONTEXT:  SQL statement "select rlogging()"
-ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:390)
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+ERROR:  plcontainer: Handle spi message failed due to error: this is the error message (plcontainer.c:537)
+CONTEXT:  PLContainer function "rlogging2"
 \! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
 FATAL:  this is the fatal message
+CONTEXT:  PLContainer function "rlogging_fatal"
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.


### PR DESCRIPTION
## Description
Used to have no error context stack, while plpython does, so add it.
Now every elog have a context,  which shows the function name.

## Tests

```
CREATE FUNCTION elog_test_basic() RETURNS void
AS $$
# container: plc_python_shared
plpy.debug('debug')
plpy.log('log')
plpy.info('info')
plpy.info(37)
plpy.info()
plpy.info('info', 37, [1, 2, 3])
plpy.notice('notice')
plpy.warning('warning')
plpy.error('error')
$$ LANGUAGE plcontainer;

SELECT elog_test_basic();
```

### Past behavior
```
INFO:  info
INFO:  37
INFO:  ()
INFO:  ('info', 37, [1, 2, 3])
NOTICE:  notice
WARNING:  warning
```
### Now behavior
```
INFO:  info
CONTEXT:  PL/Python function "elog_test_basic"
INFO:  37
CONTEXT:  PL/Python function "elog_test_basic"
INFO:  ()
CONTEXT:  PL/Python function "elog_test_basic"
INFO:  ('info', 37, [1, 2, 3])
CONTEXT:  PL/Python function "elog_test_basic"
NOTICE:  notice
CONTEXT:  PL/Python function "elog_test_basic"
WARNING:  warning
CONTEXT:  PL/Python function "elog_test_basic"
```
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
