### PR TITLE
Add python type defination PLy_ResultType

### DIFF
--- a/src/pyclient/plpy_spi.h
+++ b/src/pyclient/plpy_spi.h
@@ -12,6 +12,7 @@
 
 PyTypeObject PLy_PlanType;
 PyTypeObject PLy_SubtransactionType;
+PyTypeObject PLy_ResultType;
 
 PyObject *PLy_spi_execute(PyObject *self, PyObject *pyquery);
 

--- a/src/pyclient/pycall.c
+++ b/src/pyclient/pycall.c
@@ -97,6 +97,8 @@ int python_init() {
 	 */
 	if (PyType_Ready(&PLy_PlanType) < 0)
 			plc_elog (ERROR, "could not initialize PLy_PlanType");
+	if (PyType_Ready(&PLy_ResultType) < 0)
+			plc_elog(ERROR, "could not initialize PLy_ResultType");
 	if (PyType_Ready(&PLy_SubtransactionType) < 0)
 			plc_elog (ERROR, "could not initialize PLy_SubtransactionType");
 

--- a/tests/expected/spi_python.out
+++ b/tests/expected/spi_python.out
@@ -75,56 +75,105 @@ for r in rv:
 $$ LANGUAGE plcontainer;
 select py_spi_pexecute1();
 NOTICE:  Test query execution
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test query targetlist containing NULL
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1000, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test text
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  True
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test bool
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1000, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1001, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9001, 'sex': 'f', 'name': 'bob2', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9005, 'sex': 'm', 'name': 'alice3', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test int4
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9002, 'sex': 'm', 'name': 'bob3', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9003, 'sex': 'm', 'name': 'alice1', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9004, 'sex': 'f', 'name': 'alice2', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9005, 'sex': 'm', 'name': 'alice3', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test char
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1000, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1001, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9002, 'sex': 'm', 'name': 'bob3', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9003, 'sex': 'm', 'name': 'alice1', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9005, 'sex': 'm', 'name': 'alice3', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test text+bool+char+int4
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test results containing NULL
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1000, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1001, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  Test insert NULL
-NOTICE:  1
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1000, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1001, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 1002, 'sex': 'm', 'name': None, 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 7000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 8000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9000, 'sex': 'm', 'name': 'bob1', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9001, 'sex': 'f', 'name': 'bob2', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9002, 'sex': 'm', 'name': 'bob3', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9003, 'sex': 'm', 'name': 'alice1', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9004, 'sex': 'f', 'name': 'alice2', 'online': 0}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
 NOTICE:  {'id': 9005, 'sex': 'm', 'name': 'alice3', 'online': 1}
+CONTEXT:  PLContainer function "py_spi_pexecute1"
  py_spi_pexecute1 
 ------------------
  
@@ -166,13 +215,21 @@ for r in rv:
 $$ LANGUAGE plcontainer;
 select py_spi_pexecute2();
 NOTICE:  Test int2
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  {'age': 20, 'name': 'bob1', 'id': 8000L}
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  {'age': 20, 'name': 'bob0', 'id': 9000L}
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  Test int8
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  {'age': 40, 'name': 'alice1', 'id': 6000L}
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  {'age': 50, 'name': 'alice2', 'id': 6000L}
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  Test text + int8
+CONTEXT:  PLContainer function "py_spi_pexecute2"
 NOTICE:  {'age': 20, 'name': 'bob0', 'id': 9000L}
+CONTEXT:  PLContainer function "py_spi_pexecute2"
  py_spi_pexecute2 
 ------------------
  
@@ -221,20 +278,35 @@ for r in rv:
 $$ LANGUAGE plcontainer;
 select py_spi_pexecute3();
 NOTICE:  Test bytea
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  Test float4
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob1', 'score2': 16.75, 'score1': 8.75}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob2', 'score2': 16.875, 'score1': 8.875}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  Test float8
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob1', 'score2': 16.75, 'score1': 8.75}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob3', 'score2': 16.125, 'score1': 9.125}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob4', 'score2': 16.25, 'score1': 9.25}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  Test float4+float8
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob1', 'score2': 16.75, 'score1': 8.75}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
 NOTICE:  {'name': 'bob3', 'score2': 16.125, 'score1': 9.125}
+CONTEXT:  PLContainer function "py_spi_pexecute3"
  py_spi_pexecute3 
 ------------------
  
@@ -298,6 +370,7 @@ for r in rv:
 $$ LANGUAGE plcontainer;
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -309,14 +382,17 @@ LINE 1: select * from t4 where name=$1 order by score1
                                    ^
 HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 QUERY:  select * from t4 where name=$1 order by score1
+CONTEXT:  PLContainer function "py_spi_illegal_pexecute1"
 select py_spi_illegal_pexecute2();
 ERROR:  operator does not exist: real < bytea
 LINE 1: select * from t4 where score1<$1 order by score1
                                      ^
 HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 QUERY:  select * from t4 where score1<$1 order by score1
+CONTEXT:  PLContainer function "py_spi_illegal_pexecute2"
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -325,11 +401,14 @@ NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
 select py_spi_illegal_pexecute3();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float4
+CONTEXT:  PLContainer function "py_spi_illegal_pexecute3"
 select py_spi_illegal_pexecute4();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float8
+CONTEXT:  PLContainer function "py_spi_illegal_pexecute4"
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -337,10 +416,15 @@ NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
 
 SELECT py_spi_simple_num();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_num"
 NOTICE:  {'name': 'bob1', 'score2': 16.75, 'score1': 8.75}
+CONTEXT:  PLContainer function "py_spi_simple_num"
 NOTICE:  {'name': 'bob2', 'score2': 16.875, 'score1': 8.875}
+CONTEXT:  PLContainer function "py_spi_simple_num"
 NOTICE:  {'name': 'bob3', 'score2': 16.125, 'score1': 9.125}
+CONTEXT:  PLContainer function "py_spi_simple_num"
 NOTICE:  {'name': 'bob4', 'score2': 16.25, 'score1': 9.25}
+CONTEXT:  PLContainer function "py_spi_simple_num"
  py_spi_simple_num 
 -------------------
  
@@ -388,6 +472,7 @@ return 0
 $$ LANGUAGE plcontainer IMMUTABLE;
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -398,15 +483,19 @@ ERROR:  relation "pg_database_invalid" does not exist
 LINE 1: select datname from pg_database_invalid
                             ^
 QUERY:  select datname from pg_database_invalid
+CONTEXT:  PLContainer function "pyspi_illegal_sql"
 select pyspi_illegal_sql_pexecute();
 ERROR:  relation "pg_database_invalid" does not exist
 LINE 1: select datname from pg_database_invalid
                             ^
 QUERY:  select datname from pg_database_invalid
+CONTEXT:  PLContainer function "pyspi_illegal_sql_pexecute"
 select pyspi_bad_limit();
 ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (0) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+CONTEXT:  PLContainer function "pyspi_bad_limit"
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -419,12 +508,16 @@ DETAIL:
  Traceback (most recent call last):
   File "<string>", line 4, in pyspi_bad_limit_pexecute
 TypeError: second argument of plpy.prepare must be a sequence
+CONTEXT:  PLContainer function "pyspi_bad_limit_pexecute"
 select pyspi_bad_limit_immutable();
 ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+CONTEXT:  PLContainer function "pyspi_bad_limit_immutable"
 select pyspi_bad_limit_stable();
 ERROR:  plcontainer: Cannot handle sql ('select datname from pg_database order by datname') with fn_readonly (1) and limit (-2). Detail: SPI_ERROR_ARGUMENT (sqlhandler.c:330)
+CONTEXT:  PLContainer function "pyspi_bad_limit_stable"
 select py_spi_simple_t4();
 NOTICE:  {'name': 'bob0', 'score2': 16.5, 'score1': 8.5}
+CONTEXT:  PLContainer function "py_spi_simple_t4"
  py_spi_simple_t4 
 ------------------
  
@@ -463,7 +556,6 @@ for r in rv:
 return 0
 $$ LANGUAGE plcontainer;
 SELECT pyspi_insert_exec();
-NOTICE:  1
  pyspi_insert_exec 
 -------------------
                  0
@@ -478,7 +570,6 @@ SELECT * FROM t5 order by name;
 (3 rows)
 
 SELECT pyspi_update_exec();
-NOTICE:  1
  pyspi_update_exec 
 -------------------
                  0
@@ -493,7 +584,6 @@ SELECT * FROM t5 order by name;
 (3 rows)
 
 SELECT pyspi_delete_exec();
-NOTICE:  1
  pyspi_delete_exec 
 -------------------
                  0
@@ -548,7 +638,6 @@ for r in rv:
 return 0
 $$ LANGUAGE plcontainer;
 SELECT pyspi_insert_execp();
-NOTICE:  1
  pyspi_insert_execp 
 --------------------
                   0
@@ -563,7 +652,6 @@ SELECT * FROM t5 order by name;
 (3 rows)
 
 SELECT pyspi_update_execp();
-NOTICE:  1
  pyspi_update_execp 
 --------------------
                   0
@@ -578,7 +666,6 @@ SELECT * FROM t5 order by name;
 (3 rows)
 
 SELECT pyspi_delete_execp();
-NOTICE:  1
  pyspi_delete_execp 
 --------------------
                   0
@@ -600,7 +687,6 @@ select pyspi_select_notexist_execp();
 
 -- Test returns 0 row X 0 col.
 select pyspi_delete_notexist_execp();
-NOTICE:  0
  pyspi_delete_notexist_execp 
 -----------------------------
                            0
@@ -620,6 +706,7 @@ return 0
 $$ LANGUAGE plcontainer;
 SELECT pyspi_exec_exception();
 NOTICE:  <class 'plpy.SPIError'>
+CONTEXT:  PLContainer function "pyspi_exec_exception"
  pyspi_exec_exception 
 ----------------------
                     0
@@ -724,10 +811,13 @@ return None
 $$ LANGUAGE plcontainer;
 SELECT invalid_type_uncaught('rick');
 ERROR:  type "test" does not exist
+CONTEXT:  PLContainer function "invalid_type_uncaught"
 SELECT invalid_type_caught('rick');
 ERROR:  type "test" does not exist
+CONTEXT:  PLContainer function "invalid_type_caught"
 SELECT invalid_type_reraised('rick');
 ERROR:  type "test" does not exist
+CONTEXT:  PLContainer function "invalid_type_reraised"
 SELECT valid_type('rick');
  valid_type 
 ------------
@@ -756,5 +846,24 @@ select spi_prepared_plan_test_nested('smith');
  spi_prepared_plan_test_nested 
 -------------------------------
  there are 1 smiths
+(1 row)
+
+CREATE FUNCTION result_nrows_test() RETURNS int
+AS $$
+# container: plc_python_shared
+plan = plpy.prepare("SELECT 1 UNION SELECT 2")
+plpy.info(plan.status())
+result = plpy.execute(plan)
+if result.status() > 0:
+   return result.nrows()
+else:
+   return None
+$$ LANGUAGE plcontainer;
+select result_nrows_test();
+INFO:  True
+CONTEXT:  PLContainer function "result_nrows_test"
+ result_nrows_test 
+-------------------
+                 2
 (1 row)
 

--- a/tests/expected/test_r_1.out
+++ b/tests/expected/test_r_1.out
@@ -1,0 +1,684 @@
+set datestyle='ISO,MDY';
+select rshouldnotparse();
+ERROR:  PL/Container client exception occurred:
+DETAIL:  
+ Parse Error
+rshouldnotparse <- function(args) {
+# container: plc_r_shared
+return 'hello'
+}
+CONTEXT:  PLContainer function "rshouldnotparse"
+select rlog100();
+ rlog100 
+---------
+ 2
+(1 row)
+
+select rbool('t');
+ rbool 
+-------
+ t
+(1 row)
+
+select rbool('f');
+ rbool 
+-------
+ f
+(1 row)
+
+select rint(NULL::int2);
+ rint 
+------
+    0
+(1 row)
+
+select rint(123::int2);
+ rint 
+------
+  124
+(1 row)
+
+select rint(234::int4);
+ rint 
+------
+  236
+(1 row)
+
+select rint(345::int8);
+ rint 
+------
+  348
+(1 row)
+
+select rfloat(3.1415926535897932384626433832::float4);
+ rfloat  
+---------
+ 4.14159
+(1 row)
+
+select rfloat(3.1415926535897932384626433832::float8);
+      rfloat      
+------------------
+ 5.14159265358979
+(1 row)
+
+select rnumeric(3.1415926535897932384626433832::numeric);
+     rnumeric     
+------------------
+ 6.14159265358979
+(1 row)
+
+select rtimestamp('2012-01-02 12:34:56.789012'::timestamp);
+         rtimestamp         
+----------------------------
+ 2012-01-02 13:34:56.789011
+(1 row)
+
+select rtimestamptz('2012-01-02 12:34:56.789012 UTC+4'::timestamptz);
+         rtimestamptz          
+-------------------------------
+ 2012-01-02 08:34:56.789012-08
+(1 row)
+
+select rtext('123');
+ rtext  
+--------
+ 123foo
+(1 row)
+
+select rbyteain(rbyteaout(array[123,1,7]::int[]));
+ rbyteain  
+-----------
+ {123,1,7}
+(1 row)
+
+select rbyteain(rbyteaout(array[123,null,7]::int[]));
+   rbyteain   
+--------------
+ {123,NULL,7}
+(1 row)
+
+select rtest_mia();
+         rtest_mia          
+----------------------------
+ {{1,2,3,4,5},{6,7,8,9,10}}
+(1 row)
+
+select vec('{1.23, 1.32}'::float8[]);
+     vec     
+-------------
+ {2.23,2.32}
+(1 row)
+
+select vec('{1, 5,10, 100, 7}'::int8[]);
+      vec       
+----------------
+ {2,6,11,101,8}
+(1 row)
+
+select vec('{1.23, 1.32}'::float4[]);
+     vec     
+-------------
+ {2.23,2.32}
+(1 row)
+
+select vec('{1, 5,10, 100, 7}'::int4[]);
+      vec       
+----------------
+ {2,6,11,101,8}
+(1 row)
+
+select vec('{1, 5,10, 100, 7}'::numeric[]);
+      vec       
+----------------
+ {2,6,11,101,8}
+(1 row)
+
+select rintarr('{1,2,3,4}'::int2[]);
+ rintarr 
+---------
+      10
+(1 row)
+
+select rintarr('{1,2,3,null}'::int2[]);
+ rintarr 
+---------
+       6
+(1 row)
+
+select rintarr('{null}'::int2[]);
+ rintarr 
+---------
+       0
+(1 row)
+
+select rintarr('{{1,2,3,4},{5,6,7,8}}'::int2[]);
+ rintarr 
+---------
+      36
+(1 row)
+
+select rdimarr('{{1,2,3,4},{5,6,7,8}}'::int2[]);
+ rdimarr 
+---------
+ {2,4}
+(1 row)
+
+select rintarr('{1,2,3,4,5}'::int4[]);
+ rintarr 
+---------
+      15
+(1 row)
+
+select rintarr('{1,2,3,4,null}'::int4[]);
+ rintarr 
+---------
+      10
+(1 row)
+
+select rintarr('{null}'::int4[]);
+ rintarr 
+---------
+       0
+(1 row)
+
+select rintarr('{{1,2,3,4},{5,6,7,8}}'::int4[]);
+ rintarr 
+---------
+      36
+(1 row)
+
+select rdimarr('{{1,2,3,4},{5,6,7,8}}'::int4[]);
+ rdimarr 
+---------
+ {2,4}
+(1 row)
+
+select rintarr('{1,2,3,4,6}'::int8[]);
+ rintarr 
+---------
+      16
+(1 row)
+
+select rintarr('{1,2,3,6,null}'::int8[]);
+ rintarr 
+---------
+      12
+(1 row)
+
+select rintarr('{null}'::int8[]);
+ rintarr 
+---------
+       0
+(1 row)
+
+select rintarr('{{1,2,3,4},{5,6,7,8}}'::int8[]);
+ rintarr 
+---------
+      36
+(1 row)
+
+select rdimarr('{{1,2,3,4},{5,6,7,8}}'::int8[]);
+ rdimarr 
+---------
+ {2,4}
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,5.6}'::float8[]);
+ rfloatarr 
+-----------
+      12.5
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,null}'::float8[]);
+ rfloatarr 
+-----------
+       6.9
+(1 row)
+
+select rfloatarr('{null}'::float8[]);
+ rfloatarr 
+-----------
+         0
+(1 row)
+
+select rfloatarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::float8[]);
+ rfloatarr 
+-----------
+      38.4
+(1 row)
+
+select rdimarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::float8[]);
+ rdimarr 
+---------
+ {2,5}
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,5.6,6.7}'::float4[]);
+ rfloatarr 
+-----------
+      19.2
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,5.6,null}'::float4[]);
+ rfloatarr 
+-----------
+      12.5
+(1 row)
+
+select rfloatarr('{null}'::float4[]);
+ rfloatarr 
+-----------
+         0
+(1 row)
+
+select rfloatarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::float4[]);
+ rfloatarr 
+-----------
+      38.4
+(1 row)
+
+select rdimarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::float4[]);
+ rdimarr 
+---------
+ {2,5}
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,5.6,6.7}'::numeric[]);
+ rfloatarr 
+-----------
+      19.2
+(1 row)
+
+select rfloatarr('{1.2,2.3,3.4,5.6,null}'::numeric[]);
+ rfloatarr 
+-----------
+      12.5
+(1 row)
+
+select rfloatarr('{null}'::numeric[]);
+ rfloatarr 
+-----------
+         0
+(1 row)
+
+select rfloatarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::numeric[]);
+ rfloatarr 
+-----------
+      38.4
+(1 row)
+
+select rdimarr('{{1.2,2.3,3.4,5.6,6.7},{1.2,2.3,3.4,5.6,6.7}}'::numeric[]);
+ rdimarr 
+---------
+ {2,5}
+(1 row)
+
+select rboolarr('{1,1,0}'::bool[]);
+ rboolarr 
+----------
+        2
+(1 row)
+
+select rboolarr('{1,1,0,NULL}'::bool[]);
+ rboolarr 
+----------
+        2
+(1 row)
+
+select rboolarr('{NULL}'::bool[]);
+ rboolarr 
+----------
+        0
+(1 row)
+
+select rboolarr('{{1,1,0},{1,0,0}}'::bool[]);
+ rboolarr 
+----------
+        3
+(1 row)
+
+select rdimarr('{{1,1,0},{1,0,0}}'::bool[]);
+ rdimarr 
+---------
+ {2,3}
+(1 row)
+
+select rtimestamparr($${'2012-01-02 12:34:56.789012','2012-01-03 12:34:56.789012'}$$::timestamp[]);
+                        rtimestamparr                        
+-------------------------------------------------------------
+ {"2012-01-02 13:34:56.789011","2012-01-03 13:34:56.789011"}
+(1 row)
+
+--select rlog100_shared();
+select rpg_spi_exec('select 1');
+ rpg_spi_exec 
+--------------
+ 1
+(1 row)
+
+select rlogging();
+INFO:  this is the info message
+CONTEXT:  PLContainer function "rlogging"
+NOTICE:  this is the notice message
+CONTEXT:  PLContainer function "rlogging"
+WARNING:  this is the warning message
+CONTEXT:  PLContainer function "rlogging"
+ERROR:  this is the error message
+CONTEXT:  PLContainer function "rlogging"
+select rlogging2();
+INFO:  this is the info message
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+NOTICE:  this is the notice message
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+WARNING:  this is the warning message
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+WARNING:  plcontainer: docker reports container has been terminated due to out of memory. This could be either the container was over memory limit or inside program crashed
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+ERROR:  this is the error message
+CONTEXT:  PLContainer function "rlogging"
+SQL statement "select rlogging()"
+PLContainer function "rlogging"
+\! psql -d ${PL_TESTDB} -c "select rlogging_fatal();"
+FATAL:  this is the fatal message
+CONTEXT:  PLContainer function "rlogging_fatal"
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost
+select rsetofint4();
+ rsetofint4 
+------------
+          1
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+         10
+         11
+         12
+         13
+         14
+         15
+(15 rows)
+
+select rsetofint8();
+ rsetofint8 
+------------
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+         10
+         11
+         12
+         13
+         14
+         15
+         16
+(15 rows)
+
+select rsetofint2();
+ rsetofint2 
+------------
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+         10
+         11
+         12
+         13
+         14
+         15
+         16
+         17
+(15 rows)
+
+select rsetoffloat4();
+ rsetoffloat4 
+--------------
+          2.5
+          3.5
+          4.5
+          5.5
+          6.5
+          7.5
+          8.5
+          9.5
+         10.5
+         11.5
+         12.5
+         13.5
+         14.5
+          2.5
+          3.5
+(15 rows)
+
+select rsetoffloat8();
+ rsetoffloat8 
+--------------
+          4.5
+          5.5
+          6.5
+          7.5
+          8.5
+          9.5
+         10.5
+         11.5
+         12.5
+         13.5
+         14.5
+          4.5
+          5.5
+          6.5
+          7.5
+(15 rows)
+
+select rsetoftext();
+ rsetoftext 
+------------
+ like
+ dislike
+ hate
+ like
+ don't know
+ like
+ dislike
+(7 rows)
+
+select rsetoffloat8array();
+                 rsetoffloat8array                  
+----------------------------------------------------
+ {5.5,6.5,7.5,8.5,9.5,10.5,11.5,12.5,13.5,14.5,3.5}
+ {4.5,5.5,6.5,7.5,8.5,9.5,10.5,11.5,12.5,13.5,14.5}
+(2 rows)
+
+select rsetofint4array();
+         rsetofint4array         
+---------------------------------
+ {5,6,7,8,9,10,11,12,13,14,15,3}
+ {4,5,6,7,8,9,10,11,12,13,14,15}
+(2 rows)
+
+select rsetofint8array();
+         rsetofint8array         
+---------------------------------
+ {5,6,7,8,9,10,11,12,13,14,15,3}
+ {4,5,6,7,8,9,10,11,12,13,14,15}
+(2 rows)
+
+select rsetoftextarray();
+ rsetoftextarray 
+-----------------
+ {like}
+ {dislike}
+ {hate}
+ {like}
+ {"don't know"}
+ {like}
+ {dislike}
+ {seven}
+(8 rows)
+
+select runargs1('foo');
+ runargs1 
+----------
+ foo
+(1 row)
+
+select runargs2(123, 'foo');
+ runargs2 
+----------
+ 123foo
+(1 row)
+
+select runargs3(123, 'foo', 'bar');
+ runargs3  
+-----------
+ 123foobar
+(1 row)
+
+select runargs4(1,null,null,1);
+ runargs4 
+----------
+        4
+(1 row)
+
+select rnested_call_three('foo');
+ rnested_call_three 
+--------------------
+ foo
+(1 row)
+
+select rnested_call_two('foobar');
+ rnested_call_two 
+------------------
+ foobar
+(1 row)
+
+select rnested_call_one('foo1');
+ rnested_call_one 
+------------------
+ foo1
+(1 row)
+
+select rtestudt1( ('t', 1, 2, 3, 4, 5, 6, 'foobar')::test_type );
+ rtestudt1 
+-----------
+        10
+(1 row)
+
+select rtestudt2( (
+        array[true,false,true]::bool[],
+        array[1,2,3]::smallint[],
+        array[2,3,4]::int[],
+        array[3,4,5]::int8[],
+        array[4.5,5.5,6.5]::float4[],
+        array[5.5,6.5,7.5]::float8[],
+        array[6.5,7.5,8.5]::numeric[],
+        array['a','b','c']::varchar[])::test_type2 );
+ rtestudt2 
+-----------
+        10
+(1 row)
+
+select rtestudt6a();
+     rtestudt6a      
+---------------------
+ (t,1,2,3,4,4,6,foo)
+(1 row)
+
+select rtestudt6b();
+      rtestudt6b      
+----------------------
+ (t,1,5,8,1,4,7,foo)
+ (f,2,6,9,2,5,8,bar)
+ (t,3,7,10,3,6,9,zzz)
+(3 rows)
+
+select rtestudt8();
+ rtestudt8 
+-----------
+ (1,2,foo)
+ (3,4,bar)
+(2 rows)
+
+select rtestudt11();
+        rtestudt11         
+---------------------------
+ (1,"{2,22}","{foo,foo2}")
+ (3,"{4,44}","{bar,bar2}")
+(2 rows)
+
+select * from rtestudt13( (1,2,'a')::test_type3 );
+ a | b | c 
+---+---+---
+ 1 | 2 | a
+(1 row)
+
+--select paster('{hello, happy}','{world, birthday}',' ');
+--select rtest_spi_tup('select fname, lname,username from users order by 1,2,3');
+-- This function is of "return setof record" type which is not supported yet
+-- select rtest_spi_ta('select oid, typname from pg_type where typname = ''oid'' or typname = ''text''');
+select rvectornull_bool();
+                  rvectornull_bool                   
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_int2();
+                  rvectornull_int2                   
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_int4();
+                  rvectornull_int4                   
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_int8();
+                  rvectornull_int8                   
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_float4();
+                 rvectornull_float4                  
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_float8();
+                 rvectornull_float8                  
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+
+select rvectornull_numeric();
+                 rvectornull_numeric                 
+-----------------------------------------------------
+ {NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL}
+(1 row)
+

--- a/tests/sql/spi_python.sql
+++ b/tests/sql/spi_python.sql
@@ -518,3 +518,17 @@ select nested_call_one('pass this along');
 select spi_prepared_plan_test_one('doe');
 select spi_prepared_plan_test_one('smith');
 select spi_prepared_plan_test_nested('smith');
+
+CREATE FUNCTION result_nrows_test() RETURNS int
+AS $$
+# container: plc_python_shared
+plan = plpy.prepare("SELECT 1 UNION SELECT 2")
+plpy.info(plan.status())
+result = plpy.execute(plan)
+if result.status() > 0:
+   return result.nrows()
+else:
+   return None
+$$ LANGUAGE plcontainer;
+
+select result_nrows_test();


### PR DESCRIPTION
## Description
Add python type defination PLy_ResultType
plpy.execute() used to return python type list, now change to python type PLy_ResultType
The python type PLy_ResultType has all list attibute, also, have two functions like nrows() and status()

## Tests
```
CREATE FUNCTION result_nrows_test() RETURNS int
AS $$
# container: plc_python_shared
plan = plpy.prepare("SELECT 1 UNION SELECT 2")
plpy.info(plan.status())
result = plpy.execute(plan)
if result.status() > 0:
   return result.nrows()
else:
   return None
$$ LANGUAGE plcontainer;

select result_nrows_test();
INFO:  True
CONTEXT:  PLContainer function "result_nrows_test"
 result_nrows_test
-------------------
                 2
(1 row)
```

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
