### PR TITLE
Fix a bug that plc randomly crashes QE process in test oom

### DIFF
--- a/src/common/comm_connectivity.c
+++ b/src/common/comm_connectivity.c
@@ -30,57 +30,52 @@ static ssize_t plcSocketSend(plcConn *conn, const void *ptr, size_t len);
 
 static int plcBufferMaybeFlush(plcConn *conn, bool isForse);
 
-static int plcBufferMaybeReset(plcConn *conn, int bufType);
+static void plcBufferMaybeReset(plcConn *conn, int bufType);
 
 static int plcBufferMaybeResize(plcConn *conn, int bufType, size_t bufAppend);
+
+static void
+my_gettimeofday(struct timeval *tv)
+{
+	int retval;
+	retval = gettimeofday(tv, NULL);
+	if (retval < 0)
+		plc_elog(ERROR, "Failed to get time: %s", strerror(errno));
+}
 
 /*
  *  Read data from the socket
  */
 static ssize_t plcSocketRecv(plcConn *conn, void *ptr, size_t len) {
 	ssize_t sz = 0;
-	struct timeval start_ts, end_ts;
+	int time_count = 0;
+	int intr_count = 0;
 	int retval;
+	struct timeval start_ts, end_ts;
 
-	/* Better use clock_gettime() however it needs librt. */
-	retval = gettimeofday(&start_ts, NULL);
-	if (retval < 0) {
-		plc_elog(ERROR, "Failed to get time for hang detection: %s", strerror(errno));
-		return retval;
-	}
-
-	while (true) {
-		sz = recv(conn->sock, ptr, len, 0);
-
-		/* Only retry when needed. */
-		if (!(sz == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)))
-			break;
-
-		/* error out if timeout. */
-		retval = gettimeofday(&end_ts, NULL);
-		if (retval < 0) {
-			plc_elog(ERROR, "Failed to get time for hang detection: %s", strerror(errno));
-			return retval;
+	while((sz=recv(conn->sock, ptr, len, 0))<0) {
+		CHECK_FOR_INTERRUPTS();
+		if (errno == EINTR && intr_count++ < 5)
+			continue;
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			if (time_count==0) {
+				my_gettimeofday(&start_ts);
+				time_count++;
+			} else {
+				my_gettimeofday(&end_ts);
+				if ((end_ts.tv_sec - start_ts.tv_sec) > conn->rx_timeout_sec) {
+					plc_elog(ERROR, "rx timeout (%ds > %ds)",
+						(int) (end_ts.tv_sec - start_ts.tv_sec), conn->rx_timeout_sec);
+					return -1;
+				}
+			}
+		} else {
+			plc_elog(ERROR, "Failed to recv data: %s", strerror(errno));
 		}
-
-		if ((end_ts.tv_sec - start_ts.tv_sec) > conn->rx_timeout_sec) {
-			plc_elog(ERROR, "rx timeout (%ds > %ds)",
-				    (int) (end_ts.tv_sec - start_ts.tv_sec), conn->rx_timeout_sec);
-			return -1;
-		}
-	}
-
-	/* If receive command is terminated by SIGINT/SIGTERM, etc. */
-	if (sz == -1 && errno == EINTR) {
-		plc_elog(ERROR, "Query and PL/Container connections are terminated "
-		"by user request: %s", strerror(errno));
 	}
 
 	/* Log info if needed. */
-	if (sz < 0) {
-		plc_elog(LOG, "Query and PL/Container connections are terminated "
-		"due to: %s", strerror(errno));
-	} else if (sz == 0) {
+	if (sz == 0) {
 		plc_elog(LOG, "The peer has shut down the connection.");
 	}
 
@@ -91,14 +86,15 @@ static ssize_t plcSocketRecv(plcConn *conn, void *ptr, size_t len) {
  *  Write data to the socket
  */
 static ssize_t plcSocketSend(plcConn *conn, const void *ptr, size_t len) {
-	ssize_t sz = send(conn->sock, ptr, len, 0);
-
-	/* If receive command is terminated by SIGINT */
-	if (sz < 0 && errno == EINTR) {
-		plc_elog(ERROR, "Query and PL/Container connections are terminated by "
-		"user request: %s", strerror(errno));
+	ssize_t sz;
+	int n=0;
+	while((sz=send(conn->sock, ptr, len, 0))==-1) {
+		CHECK_FOR_INTERRUPTS();
+		if (errno == EINTR && n++ < 5)
+			continue;
+		plc_elog(ERROR, "Failed to send: %s", strerror(errno));
+		break;
 	}
-
 	return sz;
 }
 
@@ -109,7 +105,6 @@ static ssize_t plcSocketSend(plcConn *conn, const void *ptr, size_t len) {
  * Returns 0 on success, -1 on failure
  */
 static int plcBufferMaybeFlush(plcConn *conn, bool isForse) {
-	int res = 0;
 	plcBuffer *buf = conn->buffer[PLC_OUTPUT_BUFFER];
 
 	/*
@@ -127,7 +122,7 @@ static int plcBufferMaybeFlush(plcConn *conn, bool isForse) {
 			sent = plcSocketSend(conn,
 			                     buf->data + buf->pStart,
 			                     buf->pEnd - buf->pStart);
-			if (sent <= 0) {
+			if (sent < 0) {
 				plc_elog(LOG, "plcBufferMaybeFlush: Socket write failed, send "
 					"return code is %d, error message is '%s'",
 					sent, strerror(errno));
@@ -137,9 +132,7 @@ static int plcBufferMaybeFlush(plcConn *conn, bool isForse) {
 		}
 
 		// After the flush we should consider resetting the buffer
-		res = plcBufferMaybeReset(conn, PLC_OUTPUT_BUFFER);
-		if (res < 0)
-			return res;
+		plcBufferMaybeReset(conn, PLC_OUTPUT_BUFFER);
 	}
 
 	return 0;
@@ -150,9 +143,8 @@ static int plcBufferMaybeFlush(plcConn *conn, bool isForse) {
  * the buffer array if it has reached the middle of the buffer or the buffer
  * is empty
  *
- * Returns 0 on success, -1 on failure
  */
-static int plcBufferMaybeReset(plcConn *conn, int bufType) {
+static void plcBufferMaybeReset(plcConn *conn, int bufType) {
 	plcBuffer *buf = conn->buffer[bufType];
 
 	// If the buffer has no data we can reset both pointers to 0
@@ -165,13 +157,12 @@ static int plcBufferMaybeReset(plcConn *conn, int bufType) {
 	 * If our start point in a buffer has passed half of its size, we need
 	 * to move the data to the start of the buffer
 	 */
-	if (buf->pStart > buf->bufSize / 2) {
+	else if (buf->pStart > buf->bufSize / 2) {
+	// memmove is more meaningful, but here memcpy is safe
 		memcpy(buf->data, buf->data + buf->pStart, buf->pEnd - buf->pStart);
 		buf->pEnd = buf->pEnd - buf->pStart;
 		buf->pStart = 0;
 	}
-
-	return 0;
 }
 
 /*
@@ -201,9 +192,10 @@ static int plcBufferMaybeResize(plcConn *conn, int bufType, size_t bufAppend) {
 		newSize = ((dataSize * 2) / PLC_BUFFER_SIZE + 1) * PLC_BUFFER_SIZE;
 		newBuffer = (char *) PLy_malloc(newSize);
 		if (newBuffer == NULL) {
-			plc_elog(ERROR, "plcBufferMaybeFlush: Cannot allocate %d bytes "
+			// shrink failed, should not be an error
+			plc_elog(WARNING, "plcBufferMaybeFlush: Cannot allocate %d bytes "
 				"for output buffer", newSize);
-			return -1;
+			return 0;
 		}
 		isReallocated = 1;
 	}
@@ -253,9 +245,7 @@ int plcBufferAppend(plcConn *conn, char *srcBuffer, size_t nBytes) {
 
 		// First thing to check - whether we can reset the data to the beginning
 		// of the buffer, freeing up some space in the end of it
-		res = plcBufferMaybeReset(conn, PLC_OUTPUT_BUFFER);
-		if (res < 0)
-			return res;
+		plcBufferMaybeReset(conn, PLC_OUTPUT_BUFFER);
 
 		// Second check - whether we need to flush the buffer as it holds much data
 		res = plcBufferMaybeFlush(conn, false);
@@ -313,9 +303,7 @@ int plcBufferReceive(plcConn *conn, size_t nBytes) {
 
 		// First thing to consider - resetting the data in buffer to the beginning
 		// freeing up the space in the end to receive the data
-		res = plcBufferMaybeReset(conn, PLC_INPUT_BUFFER);
-		if (res < 0)
-			return res;
+		plcBufferMaybeReset(conn, PLC_INPUT_BUFFER);
 
 		// Second step - check whether we really need to resize the buffer after this
 		res = plcBufferMaybeResize(conn, PLC_INPUT_BUFFER, nBytes);
@@ -397,14 +385,14 @@ plcConn *plcConnect_inet(int port) {
 	int sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) {
 		plc_elog(ERROR, "PLContainer: Cannot create socket: %s", strerror(errno));
-		return result;
+		goto err_out1;
 	}
 
 	server = gethostbyname("localhost");
 	if (server == NULL) {
 		plc_elog(ERROR, "PLContainer: Failed to call gethostbyname('localhost'):"
 			" %s", hstrerror(h_errno));
-		return result;
+		goto err_out2;
 	}
 
 	raddr.sin_family = AF_INET;
@@ -418,7 +406,7 @@ plcConn *plcConnect_inet(int port) {
 		inet_ntop(AF_INET, &(raddr.sin_addr), ipAddr, INET_ADDRSTRLEN);
 		plc_elog(DEBUG1, "PLContainer: Failed to connect to %s: %s", ipAddr,
 			    strerror(errno));
-		return result;
+		goto err_out2;
 	}
 
 	/* FIXME: Do we need them? */
@@ -432,6 +420,11 @@ plcConn *plcConnect_inet(int port) {
 	result->uds_fn = NULL;
 
 	return result;
+
+err_out2:
+	close(sock);
+err_out1:
+	return NULL;
 }
 
 /*
@@ -466,7 +459,7 @@ plcConn *plcConnect_ipc(char *uds_fn) {
 	            sizeof(raddr)) < 0) {
 		plc_elog(DEBUG1, "PLContainer: Failed to connect to %s: %s",
 			    uds_fn, strerror(errno));
-		return NULL;
+		goto err_out;
 	}
 
 	/* Set socket receive timeout to 500ms */
@@ -479,6 +472,10 @@ plcConn *plcConnect_ipc(char *uds_fn) {
 	result->uds_fn = plc_top_strdup(uds_fn);
 
 	return result;
+
+err_out:
+	close(sock);
+	return NULL;
 }
 
 /*

--- a/src/common/comm_connectivity.c
+++ b/src/common/comm_connectivity.c
@@ -38,7 +38,7 @@ static void plcBufferMaybeReset(plcConn *conn, int bufType);
 static int plcBufferMaybeResize(plcConn *conn, int bufType, size_t bufAppend);
 
 static void
-my_gettimeofday(struct timeval *tv)
+plc_gettimeofday(struct timeval *tv)
 {
 	int retval;
 	retval = gettimeofday(tv, NULL);
@@ -63,10 +63,10 @@ static ssize_t plcSocketRecv(plcConn *conn, void *ptr, size_t len) {
 			continue;
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
 			if (time_count==0) {
-				my_gettimeofday(&start_ts);
+				plc_gettimeofday(&start_ts);
 				time_count++;
 			} else {
-				my_gettimeofday(&end_ts);
+				plc_gettimeofday(&end_ts);
 				if ((end_ts.tv_sec - start_ts.tv_sec) > conn->rx_timeout_sec) {
 					plc_elog(ERROR, "rx timeout (%ds > %ds)",
 						(int) (end_ts.tv_sec - start_ts.tv_sec), conn->rx_timeout_sec);

--- a/src/pyclient/pyerror.c
+++ b/src/pyclient/pyerror.c
@@ -103,10 +103,11 @@ void raise_execution_error(const char *format, ...) {
 		va_list args;
 		int len, res;
 
-		va_start(args, format);
 		len = 100 + 2 * strlen(format);
 		msg = (char *) malloc(len + 1);
+		va_start(args, format);
 		res = vsnprintf(msg, len, format, args);
+		va_end(args);
 		if (res < 0 || res >= len) {
 			msg = strdup("Error formatting error message string in raise_execution_error()");
 		}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
In plc pipeline, plc randomly failed, and crashes QE process. When `delete_containers`, the slot is not cleared out if some exceptions happened between `plcDisconnect` and `delete_container_slot`. So, the executing order is changed: 
* clear container slot
* disconnect plcConn
* free runtimeid
* delete backend by dockerid
* free dockerid
Additionally, some code is enhanced
## Tests
<!-- describe your test -->
No test case needed
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
