### PR TITLE
Fix a bug that faultinject_python test failed

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -584,9 +584,18 @@ void delete_containers() {
 					int res;
 					int _loop_cnt;
 
+					/* Check to see whether backend is exited or not. */
 					_loop_cnt = 0;
-					while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
-						pg_usleep(1000 * 1000L);
+					while ((res = delete_backend_if_exited(dockerid)) != 0 && _loop_cnt++ < 5) {
+						pg_usleep(200 * 1000L);
+					}
+
+					/* Force to delete the backend if needed. */
+					if (res != 0) {
+						_loop_cnt = 0;
+						while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
+							pg_usleep(1000 * 1000L);
+					}
 
 					/*
 					 * On rhel6/centos6 there is chance that delete api could fail here

--- a/src/containers.c
+++ b/src/containers.c
@@ -584,18 +584,9 @@ void delete_containers() {
 					int res;
 					int _loop_cnt;
 
-					/* Check to see whether backend is exited or not. */
 					_loop_cnt = 0;
-					while ((res = delete_backend_if_exited(dockerid)) != 0 && _loop_cnt++ < 5) {
-						pg_usleep(200 * 1000L);
-					}
-
-					/* Force to delete the backend if needed. */
-					if (res != 0) {
-						_loop_cnt = 0;
-						while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
-							pg_usleep(1000 * 1000L);
-					}
+					while ((res = plc_backend_delete(dockerid)) < 0 && _loop_cnt++ < 3)
+						pg_usleep(1000 * 1000L);
 
 					/*
 					 * On rhel6/centos6 there is chance that delete api could fail here

--- a/src/containers.c
+++ b/src/containers.c
@@ -415,14 +415,17 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 	 */
 	insert_container_slot(conf->runtimeid, dockerid, container_slot);
 
+	/*
+	 * Unblock signals after we insert the container identifier into the 
+	 * container slot for later cleanup.
+	 */
+	PG_SETMASK(&UnBlockSig);
+
 	pfree(dockerid);
 	dockerid = containers[container_slot].dockerid;
 
 	if (!conf->useContainerNetwork)
 		uds_fn = get_uds_fn(uds_dir);
-
-	/* Create a process to clean up the container after it finishes */
-	cleanup(dockerid, uds_fn);
 
 	_loop_cnt = 0;
 	while ((res = plc_backend_start(dockerid)) < 0) {
@@ -431,12 +434,6 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 		pg_usleep(2000 * 1000L);
 		plc_elog(LOG, "plc_backend_start() fails. Retrying [%d]", _loop_cnt);
 	}
-	/*
-	 * Unblock signals after we insert the container identifier into the 
-	 * container slot for later cleanup.
-	 */
-	PG_SETMASK(&UnBlockSig);
-
 	if (res < 0) {
 		if (!conf->useContainerNetwork)
 			cleanup_uds(uds_fn);
@@ -474,6 +471,9 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 #else
 	while (wait3(&wait_status, WNOHANG, NULL) > 0);
 #endif
+
+	/* Create a process to clean up the container after it finishes */
+	cleanup(dockerid, uds_fn);
 
 #ifndef PLC_PG
 	SIMPLE_FAULT_NAME_INJECTOR("plcontainer_before_container_started");


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Cleanup process must exit if container is started, so we should block signals to prevent the QE process  from being interrupted by a signal, in an accident, between `plc_backend_start ()` and `cleanup()`
## Tests
<!-- describe your test -->
No Test Needed
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
