### PR TITLE
Fix parseTypeString() signature changes & ignore sign when comparing …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,7 @@ OBJS = $(foreach FILE,$(FILES),$(subst .c,.o,$(FILE)))
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 
-ifeq ($(PLC_PG),yes)
-   override CFLAGS += -DPLC_PG  -Wno-sign-compare
-endif
+override CFLAGS += -DPLC_PG  -Wno-sign-compare
 
 # FIXME: We might need a configure script to handle below checks later.
 # See https://github.com/greenplum-db/plcontainer/issues/322

--- a/src/sqlhandler.c
+++ b/src/sqlhandler.c
@@ -353,11 +353,7 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 				}
 				for (i = 0; i < msg->nargs; i++) {
 					if (msg->args[i].type.type == PLC_DATA_TEXT) {
-#ifdef PLC_PG
 						parseTypeString(msg->args[i].type.typeName, &type_oid, &typemod, false);
-#else						
-						parseTypeString(msg->args[i].type.typeName, &type_oid, &typemod);
-#endif						
 						plc_plan->argOids[i] = type_oid;
 					} else if (msg->args[i].type.type == PLC_DATA_INT4) {
 						/*for R only*/


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Signature of parseTypeString is changed in gpdb master now.
And force use `-Wno-sign-compare`
## Tests
<!-- describe your test -->
Just fix function call, no test case
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
