### PR TITLE
Source greenplum_path to lacate pygresql.pg python library.

### DIFF
--- a/concourse/scripts/run_plcontainer_resgroup_tests.sh
+++ b/concourse/scripts/run_plcontainer_resgroup_tests.sh
@@ -39,6 +39,11 @@ pushd gpdb_src
             --disable-gpcloud --disable-gpfdist --disable-orca \
             --disable-pxf
 popd
+
+mkdir /usr/local/greenplum-db-devel
+tar -zxvf gpdb_binary/bin_gpdb.tar.gz -C /usr/local/greenplum-db-devel
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+
 pushd gpdb_src/src/test/isolation2
 make
 scp -r pg_isolation2_regress mdw:/usr/local/greenplum-db-devel/lib/postgresql/pgxs/src/test/regress/


### PR DESCRIPTION
This fixes the isolation2 regression caused by gpdb commit
a473abf 'Allow include files to be added in an isolation2 test.'

Co-authored-by: Haozhou Wang <hawang@pivotal.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Tests
<!-- describe your test -->
fix regresion. no test needed
## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
