### PR TITLE
Remove checking version of curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,8 @@ CURL_CONFIG = $(shell which curl-config || echo no)
 ifneq ($(CURL_CONFIG),no)
   CURL_VERSION  = $(shell $(CURL_CONFIG) --version | cut -d" " -f2)
   VERSION_CHECK = $(shell expr $(CURL_VERSION) \>\= 7.40.0)
-ifeq ($(VERSION_CHECK),1)
   override CFLAGS += $(shell $(CURL_CONFIG) --cflags)
   SHLIB_LINK = $(shell $(CURL_CONFIG) --libs)
-else
-  $(error curl version is < 7.40, please update your libcurl installation.)
-endif
 else
   $(error curl-config is not found, please check libcurl installation.)
 endif


### PR DESCRIPTION
## Description
Since plcontainer does no longer support centos6, the curl of supported platform
has unix domain socket support. Centos 7 has a low version of 7.29.0, but its curl
is patched with unix domain socket
## Tests
<!-- describe your test -->

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
