### PR TITLE
add process backend support for debugging

### DIFF
--- a/src/common/comm_server.c
+++ b/src/common/comm_server.c
@@ -199,7 +199,7 @@ int start_listener() {
 	if (strcasecmp("true", use_container_network) == 0) {
 		sock = start_listener_inet();
 	} else if (strcasecmp("false", use_container_network) == 0){
-		if (geteuid() != 0 || getuid() != 0) {
+		if ((CurrentBackendType == BACKEND_DOCKER) && (geteuid() != 0 || getuid() != 0)) {
 			plc_elog(ERROR, "Must run as root and then downgrade to usual user.");
 			return -1;
 		}

--- a/src/containers.c
+++ b/src/containers.c
@@ -370,17 +370,7 @@ plcConn *start_backend(runtimeConfEntry *conf) {
 	time_t rawtime;
 	struct tm *timeinfo;
 
-
-	/*
-	 * Hardcode as Docker at this moment. In the future the type should
-	 * be set in conf.
-	 */
-	enum PLC_BACKEND_TYPE plc_backend_type = BACKEND_DOCKER;
-
 	container_slot = find_container_slot();
-
-	plc_backend_prepareImplementation(plc_backend_type);
-
 	/*
 	 *  Here the uds_dir is only used by connection of domain socket type.
 	 *  It remains NULL for connection of non domain socket type.

--- a/src/plc_backend_api.h
+++ b/src/plc_backend_api.h
@@ -44,6 +44,8 @@ enum PLC_BACKEND_TYPE {
 	UNIMPLEMENT_TYPE
 };
 
+extern enum PLC_BACKEND_TYPE CurrentBackendType;
+
 void plc_backend_prepareImplementation(enum PLC_BACKEND_TYPE imptype);
 
 /* interfaces for plc backend. */

--- a/src/plc_configuration.c
+++ b/src/plc_configuration.c
@@ -649,7 +649,11 @@ char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_
 			
 			gpdb_dir_sz = strlen(IPC_GPDB_BASE_DIR) + 1 + 16 + 1 + 16 + 1 + 4 + 1;
 			*uds_dir = pmalloc(gpdb_dir_sz);
-			sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
+			if (CurrentBackendType == BACKEND_DOCKER) {
+                sprintf(*uds_dir, "%s.%d.%d.%d", IPC_GPDB_BASE_DIR, getpid(), domain_socket_no++, container_slot);
+            } else if (CurrentBackendType == BACKEND_PROCESS) {
+			    sprintf(*uds_dir, "%s", IPC_GPDB_BASE_DIR);
+            }
 			volumes[i] = pmalloc(10 + gpdb_dir_sz + strlen(IPC_CLIENT_DIR));
 			sprintf(volumes[i], " %c\"%s:%s:rw\"", comma, *uds_dir, IPC_CLIENT_DIR);
 			totallen += strlen(volumes[i]);

--- a/src/plc_process_api.c
+++ b/src/plc_process_api.c
@@ -29,18 +29,16 @@
 
 int plc_process_create_container(runtimeConfEntry *conf, char **name, int container_id, char **uds_dir) {
     (void)(name);
-
-	bool has_error;
-	char *volumeShare = get_sharing_options(conf, container_id, &has_error, uds_dir);
+    bool has_error;
+    char *volumeShare = get_sharing_options(conf, container_id, &has_error, uds_dir);
     (void)(volumeShare);
-
-	/*
-	 *  no shared volumes should not be treated as an error, so we use has_error to
-	 *  identifier whether there is an error when parse sharing options.
-	 */
-	if (has_error == true) {
-		return -1;
-	}
+/*
+ *  no shared volumes should not be treated as an error, so we use has_error to
+ *  identifier whether there is an error when parse sharing options.
+ */
+    if (has_error == true) {
+        return -1;
+    }
 
     pid_t pid = -1;
     int res = 0;
@@ -52,12 +50,17 @@ int plc_process_create_container(runtimeConfEntry *conf, char **name, int contai
         if ((env_str = getenv("GPHOME")) == NULL) {
             plc_elog (ERROR, "GPHOME is not set");
         } else {
-            sprintf(binaryPath, "%s/bin/plcontainer_clients/pyclient", env_str);
+            if (strstr(conf->command, "pyclient") != NULL) {
+                sprintf(binaryPath, "%s/bin/plcontainer_clients/pyclient", env_str);
+            } else {
+                sprintf(binaryPath, "%s/bin/plcontainer_clients/rclient", env_str);
+            }
         }
         char uid_string[1024] = {0};
         char gid_string[1024] = {0};
         sprintf(uid_string, "EXECUTOR_UID=%d", getuid());
         sprintf(gid_string, "EXECUTOR_GID=%d", getgid());
+        // TODO add more environment variables needed.
         char *const env[] = {
             "USE_CONTAINER_NETWORK=false",
             uid_string,
@@ -74,44 +77,43 @@ int plc_process_create_container(runtimeConfEntry *conf, char **name, int contai
     sprintf(*name, "%d", pid); 
 
     backend_log(LOG, "create backend process with name:%s", *name); 
-	
-	return res;
+    return res;
 }
 
 int plc_process_start_container(const char *name) {
-	int res = 0;
+    int res = 0;
     backend_log(LOG, "start backend process with name:%s", name); 
-	return res;
+    return res;
 }
 
 int plc_process_kill_container(const char *name) {
-	int res = 0;
-	int pid = atoi(name);
+    int res = 0;
+    int pid = atoi(name);
     kill(pid, SIGKILL);
     backend_log(LOG, "kill backend process with name:%s", name); 
-	return res;
+    return res;
 }
 
 int plc_process_inspect_container(const char *name, char **element, plcInspectionMode type) {
-	int res = 0;
+    int res = 0;
     *element = palloc(64);
     sprintf(*element, "process:%s type:%d", name, type); 
     backend_log(LOG, "inspect backend process with name:%s", name); 
-	return res;
+    return res;
 }
 
 int plc_process_wait_container(const char *name) {
-	int res = 0;
+    int res = 0;
     int pid = atoi(name);
     waitpid(pid, &res, 0);
     backend_log(LOG, "wait backend process with name:%s", name); 
-	return res;
+    return res;
 }
 
 int plc_process_delete_container(const char *name) {
-	int res = 0;
-	int pid = atoi(name);
+    int res = 0;
+    int pid = atoi(name);
     kill(pid, SIGKILL);
     backend_log(LOG, "delete backend process with name:%s", name); 
-	return res;
+    return res;
 }

--- a/src/plc_process_api.c
+++ b/src/plc_process_api.c
@@ -47,9 +47,15 @@ int plc_process_create_container(runtimeConfEntry *conf, char **name, int contai
     if ((pid = fork()) == -1) {
         res = -1;
     } else if (pid == 0) {
-        char *binaryPath = "/home/gpadmin/workspace/tools/gpdbmaster/bin/plcontainer_clients/pyclient";
-        char uid_string[1024];
-        char gid_string[1024];
+        char *env_str;
+        char binaryPath[1024] = {0};
+        if ((env_str = getenv("GPHOME")) == NULL) {
+            plc_elog (ERROR, "GPHOME is not set");
+        } else {
+            sprintf(binaryPath, "%s/bin/plcontainer_clients/pyclient", env_str);
+        }
+        char uid_string[1024] = {0};
+        char gid_string[1024] = {0};
         sprintf(uid_string, "EXECUTOR_UID=%d", getuid());
         sprintf(gid_string, "EXECUTOR_GID=%d", getgid());
         char *const env[] = {

--- a/src/plc_process_api.c
+++ b/src/plc_process_api.c
@@ -1,0 +1,111 @@
+/*------------------------------------------------------------------------------
+ *
+ * Copyright (c) 2016-Present Pivotal Software, Inc
+ *
+ *------------------------------------------------------------------------------
+ */
+
+
+#include "postgres.h"
+#include "utils/guc.h"
+#include "libpq/libpq.h"
+#include "miscadmin.h"
+#include "libpq/libpq-be.h"
+#include "common/comm_utils.h"
+#include "plc_process_api.h"
+#include "plc_backend_api.h"
+#ifndef PLC_PG
+  #include "cdb/cdbvars.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pwd.h>
+#include <unistd.h>
+#include <curl/curl.h>
+#include <json-c/json.h>
+#include <sys/wait.h>
+
+int plc_process_create_container(runtimeConfEntry *conf, char **name, int container_id, char **uds_dir) {
+    (void)(name);
+
+	bool has_error;
+	char *volumeShare = get_sharing_options(conf, container_id, &has_error, uds_dir);
+    (void)(volumeShare);
+
+	/*
+	 *  no shared volumes should not be treated as an error, so we use has_error to
+	 *  identifier whether there is an error when parse sharing options.
+	 */
+	if (has_error == true) {
+		return -1;
+	}
+
+    pid_t pid = -1;
+    int res = 0;
+    if ((pid = fork()) == -1) {
+        res = -1;
+    } else if (pid == 0) {
+        char *binaryPath = "/home/gpadmin/workspace/tools/gpdbmaster/bin/plcontainer_clients/pyclient";
+        char uid_string[1024];
+        char gid_string[1024];
+        sprintf(uid_string, "EXECUTOR_UID=%d", getuid());
+        sprintf(gid_string, "EXECUTOR_GID=%d", getgid());
+        char *const env[] = {
+            "USE_CONTAINER_NETWORK=false",
+            uid_string,
+            gid_string,
+            NULL
+        };
+
+        execle(binaryPath, binaryPath, NULL, env);
+        exit(EXIT_FAILURE);
+    }
+
+    // parent, continue......
+    *name = palloc(64);
+    sprintf(*name, "%d", pid); 
+
+    backend_log(LOG, "create backend process with name:%s", *name); 
+	
+	return res;
+}
+
+int plc_process_start_container(const char *name) {
+	int res = 0;
+    backend_log(LOG, "start backend process with name:%s", name); 
+	return res;
+}
+
+int plc_process_kill_container(const char *name) {
+	int res = 0;
+	int pid = atoi(name);
+    kill(pid, SIGKILL);
+    backend_log(LOG, "kill backend process with name:%s", name); 
+	return res;
+}
+
+int plc_process_inspect_container(const char *name, char **element, plcInspectionMode type) {
+	int res = 0;
+    *element = palloc(64);
+    sprintf(*element, "process:%s type:%d", name, type); 
+    backend_log(LOG, "inspect backend process with name:%s", name); 
+	return res;
+}
+
+int plc_process_wait_container(const char *name) {
+	int res = 0;
+    int pid = atoi(name);
+    waitpid(pid, &res, 0);
+    backend_log(LOG, "wait backend process with name:%s", name); 
+	return res;
+}
+
+int plc_process_delete_container(const char *name) {
+	int res = 0;
+	int pid = atoi(name);
+    kill(pid, SIGKILL);
+    backend_log(LOG, "delete backend process with name:%s", name); 
+	return res;
+}

--- a/src/plc_process_api.h
+++ b/src/plc_process_api.h
@@ -1,0 +1,26 @@
+/*------------------------------------------------------------------------------
+ *
+ * Copyright (c) 2017-Present Pivotal Software, Inc
+ *
+ *------------------------------------------------------------------------------
+ */
+
+
+#ifndef PLC_PROCESS_API_H
+#define PLC_PROCESS_API_H
+
+#include "plc_configuration.h"
+
+int plc_process_create_container(runtimeConfEntry *conf, char **name, int container_slot, char **uds_dir);
+
+int plc_process_start_container(const char *name);
+
+int plc_process_kill_container(const char *name);
+
+int plc_process_inspect_container(const char *name, char **element, plcInspectionMode type);
+
+int plc_process_wait_container(const char *name);
+
+int plc_process_delete_container(const char *name);
+
+#endif /* PLC_PROCESS_API_H */


### PR DESCRIPTION
## Description
Add PROCESS backend support without container needed, it could be used for testing locally. 
Introduce a new GUC: plcontainer.backend_type, the default value is "docker" and valid values is "docker", "process".

## Tests
This PR is just for testing.

## Additional Notes
Usage:
set plcontainer.backend_type to 'process';

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
