### PR TITLE
coordinator can terminate the R server process

### DIFF
--- a/src/common/comm_channel.c
+++ b/src/common/comm_channel.c
@@ -966,8 +966,8 @@ static int send_plcid(plcConn *conn, plcMsgPLCId *mid) {
 	res |= send_int32(conn, mid->sessionid);
 	res |= send_int32(conn, mid->pid);
 	res |= send_int32(conn, mid->ccnt);
+	res |= send_int32(conn, mid->action);
 	res |= send_cstring(conn, mid->runtimeid);
-
 	res |= message_end(conn);
 	channel_elog(WARNING, "Finished sending plc id message");
 	return res;
@@ -1367,6 +1367,7 @@ static int receive_plcid(plcConn *conn, plcMessage **mPlcId) {
 	res |= receive_int32(conn, &(ret->sessionid));
 	res |= receive_int32(conn, &(ret->pid));
 	res |= receive_int32(conn, &(ret->ccnt));
+	res |= receive_int32(conn, &(ret->action));
 	res |= receive_cstring(conn, &(ret->runtimeid));
 	channel_elog(WARNING, "Finished receiving id message");
 	return res;

--- a/src/include/common/comm_shm.h
+++ b/src/include/common/comm_shm.h
@@ -49,9 +49,8 @@ typedef struct requester_info_entry
 
 typedef enum QeRequestType
 {
-	CREATE_SERVER_DEBUG = 1,
-	DESTROY_SERVER_DEBUG = 2,
-	DESTROY_SERVER_DOCKER = 3,
+	CREATE_SERVER = 1,
+	DESTROY_SERVER = 2,
 	UNKNOWN_REQUEST = -99,
 } QeRequestType;
 
@@ -84,6 +83,7 @@ typedef struct QeRequest
 	int conn; /* gp_session_id */
 	QeRequestType requestType; /* type of request from QE */
 	char containerId[16]; /* container id (pid of stand alone, for debug mode only)  */
+	pid_t server_pid; /* SERVER PID */
 } QeRequest;
 
 typedef struct ShmqBufferStatus

--- a/src/include/common/messages/message_plcid.h
+++ b/src/include/common/messages/message_plcid.h
@@ -15,6 +15,7 @@ typedef struct plcMsgPLCId {
 	int sessionid;
 	int pid;
 	int ccnt;
+	int action;
 	char *runtimeid;
 } plcMsgPLCId;
 

--- a/src/include/plc/containers.h
+++ b/src/include/plc/containers.h
@@ -20,7 +20,8 @@ char *parse_container_meta(const char *source);
 
 /* return the port of a started container, -1 if the container isn't started */
 plcContext *get_container_context(const char *runtime_id);
-
+/* Function send delete container control messageto coordinator */ 
+int plcontainer_delete_container();
 /* Function deletes all the containers */
 void reset_containers(void);
 

--- a/src/include/plc/plc_coordinator.h
+++ b/src/include/plc/plc_coordinator.h
@@ -8,5 +8,18 @@
 #ifndef _CO_COORDINATOR_H
 #define _CO_COORDINATOR_H
 
+/* the container status key */
+typedef struct ContainerKey
+{
+	pid_t       qe_pid;
+	int         conn;
+} ContainerKey;
 
+/* the container status entry */
+typedef struct ContainerEntry
+{
+	ContainerKey    key;		        /* hash key */
+	char            containerId[16];    /* for container */
+	pid_t           stand_alone_pid;    /* for stand alone mode */
+} ContainerEntry;
 #endif /* _CO_COORDINATOR_H */

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -252,7 +252,7 @@ Datum plcontainer_call_handler(PG_FUNCTION_ARGS) {
 static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
                                              plcProcInfo *proc) {
 	char *runtime_id;
-	plcContext *ctx;
+	plcContext *ctx = NULL;
 	plcConn *conn;
 	int message_type;
 	plcMsgCallreq *req = NULL;
@@ -351,6 +351,7 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 	}
 	PG_CATCH();
 	{
+		plcontainer_delete_container();
 		plcontainer_abort_open_subtransactions(save_subxact_level);
 		plcCallRecursiveLevel--;
 		PG_RE_THROW();


### PR DESCRIPTION
When error happened in gpdb, coordinator can terminate the correspond R server process

1. add action in plcontainer control message to coordinator
2. add destroy_container in coordinator
3. send destroy message to aux process
4. add hash table to store the container/process info
(in stand alone mode the hash table is in coordinator, otherwise it is in aux)
5. kill R server process in stand alone mode

Tests can be covered by e2e test.
