### PR TITLE
Track containers' status and delete exited containers

### DIFF
--- a/src/include/plc/plc_coordinator.h
+++ b/src/include/plc/plc_coordinator.h
@@ -22,6 +22,7 @@ typedef struct ContainerEntry
 	ContainerKey    key;		        /* hash key */
 	char            containerId[16];    /* for container */
 	pid_t           stand_alone_pid;    /* for stand alone mode */
+	char* 			status;
 } ContainerEntry;
 
 #endif /* _CO_COORDINATOR_H */

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -519,6 +519,32 @@ int plc_docker_get_container_state(const char *name, char **result) {
 	return res;
 }
 
+int plc_docker_get_container_status(const char *name, char **result) {
+	plcCurlBuffer *response = NULL;
+	char *method = "/containers/%s/stats?stream=false";
+	char *url = NULL;
+	int res = 0;
+
+	url = palloc(strlen(method) + strlen(name) + 2);
+	sprintf(url, method, name);
+	response = plcCurlRESTAPICall(PLC_HTTP_GET, url, NULL);
+	res = response->status;
+
+	if (res == 200) {
+		res = 0;
+	} else if (res >= 0) {
+		snprintf(backend_error_message, sizeof(backend_error_message),
+		         "Failed to get container %s state, return code: %d, detail: %s", name, res, response->data);
+		res = -1;
+	}
+
+	*result = pstrdup(response->data);
+
+	pfree(url);
+
+	return res;
+}
+
 static int docker_inspect_string(char *buf, char **element, plcInspectionMode type) {
 	int i;
 	struct json_object *response = NULL;


### PR DESCRIPTION
1. add container status hash map in aux process
2. add entry in hash map when a container is created
3. check container status, delete exited container

test is covered by e2e tests