### PR TITLE
quick fix stand alone mode crash bug

### DIFF
--- a/src/plc_coordinator.c
+++ b/src/plc_coordinator.c
@@ -318,7 +318,9 @@ plc_coordinator_aux_main(Datum datum)
         if (rc & WL_POSTMASTER_DEATH)
             break;
         receive_message();
-        update_containers_status();
+        if (!plcontainer_stand_alone_mode) {
+            update_containers_status();
+        }
         sleep(2);
     }
 


### PR DESCRIPTION
test can be covered by developer-only-mode's e2e tests.