### PR TITLE
stop and delete container when the db session exited

### DIFF
--- a/src/containers.c
+++ b/src/containers.c
@@ -103,7 +103,7 @@ static plcContext *get_new_container_ctx(const char *runtime_id)
 	plcContextInit(ctx);
 
 	res = get_new_container_from_coordinator(runtime_id, ctx);
-    sleep(2);
+    sleep(10);
 	if (res != 0){
 		/* TODO: Using errors instead of elog */
 		elog(ERROR, "Cannot find an available container");

--- a/src/plcontainer.proto
+++ b/src/plcontainer.proto
@@ -25,6 +25,7 @@ enum PlcDataType {
     COMPOSITE = 5;
     ARRAY = 6;
     SETOF = 7;
+    UNKNOWN = 100;
 }
 
 message ScalarData {

--- a/src/proto/client.cc
+++ b/src/proto/client.cc
@@ -56,7 +56,7 @@ bool PLContainerClient::isSetOf(const plcTypeInfo *type) {
 
 
 PlcDataType PLContainerClient::GetDataType(const plcTypeInfo *type) {
-    PlcDataType ret;
+    PlcDataType ret = UNKNOWN;
     switch (type->type) {
     case PLC_DATA_INT1:
         ret = LOGICAL;
@@ -210,10 +210,10 @@ void PLContainerClient::InitCallRequest(const FunctionCallInfo fcinfo, const plc
     }
 }
 Datum PLContainerClient::GetCallResponseAsDatum(const FunctionCallInfo fcinfo, plcProcInfo *proc, const ScalarData &response) {
-    Datum retresult;
+    Datum retresult = (Datum)0;
 
     if (response.isnull()) {
-        return (Datum)0;
+        return retresult;
     }
 
     fcinfo->isnull = false;


### PR DESCRIPTION
1. check session pid, when the process exited, delete container
2. add UNKNOWN datatype in msg proto
3. remove useless log message

Tests can be covered by e2e tests in non-standalone mode