### PR TITLE
set invalid status if grpc channel create failed.

### DIFF
--- a/src/proto/client.cc
+++ b/src/proto/client.cc
@@ -445,6 +445,7 @@ void PLCoordinatorClient::StartContainer(const StartContainerRequest &request, S
     grpc::Status status = stub_->StartContainer(&context, request, &response);
     if (!status.ok()) {
         plc_elog(ERROR, "StartContainer RPC failed., error:%s", status.error_message().c_str());
+        response.set_status(1);
     }
     plc_elog(DEBUG1, "StartContainer response:%s", response.DebugString().c_str());
     plc_elog(DEBUG1, "StartContainer finished with status %d", status.error_code());
@@ -456,6 +457,7 @@ void PLCoordinatorClient::StopContainer(const StopContainerRequest &request, Sto
     grpc::Status status = stub_->StopContainer(&context, request, &response);
     if (!status.ok()) {
         plc_elog(ERROR, "StopContainer RPC failed., error:%s", status.error_message().c_str());
+        response.set_status(1);
     }
     plc_elog(DEBUG2, "StopContainer response:%s", response.DebugString().c_str());
     plc_elog(DEBUG1, "StopContainer finished with status %d", status.error_code());


### PR DESCRIPTION
## Description
set invalid status if grpc channel create failed.

## Tests
Existing test cases are enough to cover this issue.

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
