### PR TITLE
fix crash for sql message

### DIFF
--- a/src/common/comm_channel.c
+++ b/src/common/comm_channel.c
@@ -1112,6 +1112,7 @@ static int receive_sql_unprepare(plcConn *conn, plcMessage **mStmt) {
 	channel_elog(WARNING, "Receiving spi unprepare request");
 	res |= receive_int64(conn, &pplan);
 	ret->pplan = (void *) pplan;
+	ret->statement = NULL;
 
 	channel_elog(WARNING, "Received spi unprepare request and returned %d", res);
 	return res;
@@ -1170,6 +1171,7 @@ static int receive_sql_pexecute(plcConn *conn, plcMessage **mStmt) {
 	res |= receive_int64(conn, &ret->limit);
 	res |= receive_int64(conn, &pplan);
 	ret->pplan = (void *) pplan;
+	ret->statement = NULL;
 
 	channel_elog(WARNING, "Received spi pexecute request and returned %d", res);
 	return res;


### PR DESCRIPTION
## Description
For sql message, if some error happens, the error message will show the statement field of sql message, but this field don't be inited for some sql type. Thus, if this kind of error happens, the process will crash.

## Tests
Existing test case will be covered.

## Additional Notes
<!-- Notes regarding deployment concerns, or other impacted areas of the system. -->

## User Story or Issue
<!-- This should include a link to a user story or issue related to this pull request -->
