### PR TITLE
Fix plcontainer crash for unsupport feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 # See https://github.com/greenplum-db/plcontainer/issues/322
 
 # Plcontainer version
-PLCONTAINER_VERSION = $(shell git describe)
+PLCONTAINER_VERSION = $(shell git describe --tags)
 ifeq ($(PLCONTAINER_VERSION),)
   $(error can not determine the plcontainer version)
 else

--- a/src/pyclient/Makefile
+++ b/src/pyclient/Makefile
@@ -66,6 +66,8 @@ clean:
 	rm -f bin/$(CLIENT)
 	rm -f $(common_dep)
 	rm -rf $(DEPDIR)
+	rm -rf $(PLCONTAINER_DIR)/common/*.o
+	rm -rf $(PLCONTAINER_DIR)/common/*.d
 
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d

--- a/src/sqlhandler.c
+++ b/src/sqlhandler.c
@@ -301,6 +301,10 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 						} else {
 							/* A bit heavy to populate plcTypeInfo. */
 							fill_type_info(NULL, plc_plan->argOids[i], pexecType);
+							if (pexecType->type == PLC_DATA_ARRAY || pexecType->type == PLC_DATA_UDT)
+							{
+								plc_elog(ERROR, "Array and Udt are not supported for execute with plan");
+							}
 							values[i] = pexecType->infunc(msg->args[i].data.value, pexecType);
 							nulls[i] = ' ';
 						}

--- a/tests/expected/function_python3.out
+++ b/tests/expected/function_python3.out
@@ -576,3 +576,9 @@ create function pseudotype_result(anyelement) returns anyarray as $$
 # container: plc_python3_shared
 pass;
 $$ language plcontainer;
+create function exec_prepare_array_error(x int4[]) RETURNS text AS $$
+# container: plc_python3_shared
+plan = plpy.prepare("SELECT ($1)", ["int4[]"])
+plpy.execute(plan, [x])
+return "should not reach here"
+$$ language plcontainer;

--- a/tests/expected/test_python3.out
+++ b/tests/expected/test_python3.out
@@ -669,6 +669,9 @@ select * from pytestudtrecord2() as t(a int, b int, c varchar);
  3 | 4 | bar
 (2 rows)
 
+select exec_prepare_array_error(array[1,2,3]);
+ERROR:  plcontainer: Array and Udt are not supported for execute with plan (sqlhandler.c:306)
+CONTEXT:  PLContainer function "exec_prepare_array_error"
 select pyreturnsetofint8(2), pyreturnsetofint8(3);
  pyreturnsetofint8 | pyreturnsetofint8 
 -------------------+-------------------

--- a/tests/sql/function_python3.sql
+++ b/tests/sql/function_python3.sql
@@ -672,3 +672,10 @@ create function pseudotype_result(anyelement) returns anyarray as $$
 # container: plc_python3_shared
 pass;
 $$ language plcontainer;
+
+create function exec_prepare_array_error(x int4[]) RETURNS text AS $$
+# container: plc_python3_shared
+plan = plpy.prepare("SELECT ($1)", ["int4[]"])
+plpy.execute(plan, [x])
+return "should not reach here"
+$$ language plcontainer;

--- a/tests/sql/test_python3.sql
+++ b/tests/sql/test_python3.sql
@@ -107,6 +107,7 @@ select * from pytestudt13( (1,2,'a')::test_type3 );
 select pytestudt16();
 select * from pytestudtrecord1() as t(a int, b int, c varchar);
 select * from pytestudtrecord2() as t(a int, b int, c varchar);
+select exec_prepare_array_error(array[1,2,3]);
 select pyreturnsetofint8(2), pyreturnsetofint8(3);
 select pybadint();
 select pybadfloat8();


### PR DESCRIPTION
1. Array/UDT for SPI prepare argument are not supported,
   fix crash when such arguments are passed into prepare statement. Now an error will be thrown to notify users that such argument types are not supported.
2. Regression tests updated.