### PR TITLE
Fix plcontainer crash for unsupported feature

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -5,12 +5,9 @@
 groups:
 - name: plcontainer
   jobs:
-  - plcontainer_build_centos6
   - plcontainer_build_centos7
   - plcontainer_build_python_image
   - plcontainer_build_r_image
-  - plcontainer_function_test_centos6
-  - plcontainer_resgroup_test_centos6
   - plcontainer_function_test_centos7
   - plcontainer_resgroup_test_centos7
 
@@ -114,7 +111,6 @@ resources:
     branch: {{ccp-git-branch}}
     private_key: {{ccp-git-key}}
     uri: {{ccp-git-remote}}
-    tag_filter: {{ccp-tag-filter}}
 
 - name: plcontainer_src
   type: git
@@ -150,13 +146,6 @@ resources:
       bucket_path: clusters-google/
 
 # Docker images
-
-- name: centos-gpdb-dev-6
-  type: docker-image
-  source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: '6-gcc6.2-llvm3.7'
-
 - name: centos-gpdb-dev-7
   type: docker-image
   source:
@@ -164,15 +153,6 @@ resources:
     tag: 7-gcc6.2-llvm3.7
 
 # S3 Input and intermediate binaries
-
-- name: plr_gpdb5_centos6_build
-  type: s3
-  source:
-    bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: build/gpdb5/plr/centos6/plr-devel.gppkg
 - name: plr_gpdb5_centos7_build
   type: s3
   source:
@@ -254,15 +234,6 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: {{bin_gpdb_centos7_versioned_file}}
 
-- name: bin_gpdb_centos6
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: {{bin_gpdb_centos_versioned_file}}
-
 - name: plcontainer_gpdb_centos7_build
   type: s3
   source:
@@ -272,44 +243,12 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: build/gpdb5/plcontainer/plcontainer-concourse-centos7.gppkg
 
-- name: plcontainer_gpdb_centos6_build
-  type: s3
-  source:
-    bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: build/gpdb5/plcontainer/plcontainer-concourse-centos6.gppkg
-
-
-
 ##################################### JOBS #####################################
 ################################################################################
 
 jobs:
 
 # Build PL/Container GP Package
-- name: plcontainer_build_centos6
-  max_in_flight: 4
-  plan:
-  - aggregate:
-    - get: bin_gpdb_centos6
-    - get: gpdb_src
-    - get: plcontainer_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-    - get: plr
-      resource: plr_gpdb5_centos6_build
-  - task: plcontainer_gpdb_build
-    file: plcontainer_src/concourse/tasks/plcontainer_build.yml
-    image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-  - aggregate:
-    - put: plcontainer_gpdb_centos6_build
-      params:
-        file: plcontainer_gpdb_build/plcontainer-concourse.gppkg
-
 - name: plcontainer_build_centos7
   max_in_flight: 4
   plan:
@@ -331,112 +270,6 @@ jobs:
       params:
         file: plcontainer_gpdb_build/plcontainer-concourse.gppkg
 
-
-- name: plcontainer_function_test_centos6
-  plan:
-  - aggregate:
-    - get: plcontainer_src
-      passed:
-      - plcontainer_build_centos6
-    - get: gpdb_src
-    - get: gpdb_binary
-      resource: bin_gpdb_centos6
-    - get: ccp_src
-      passed: [plcontainer_build_python_image, plcontainer_build_r_image]
-    - get: centos-gpdb-dev-6
-    - get: plcontainer_pyclient_docker_image
-      resource: plcontainer_docker_image_centos_python
-      passed: [plcontainer_build_python_image]
-      trigger: true
-    - get: plcontainer_rclient_docker_image
-      resource: plcontainer_docker_image_centos_r
-      passed: [plcontainer_build_r_image]
-      trigger: true
-    - get: plcontainer_gpdb_centos6_build
-      passed: [plcontainer_build_centos6]
-      trigger: true
-  - put: terraform
-    params:
-      <<: *ccp_default_params
-      vars:
-        instance_type: n1-standard-4
-        PLATFORM: centos6
-        disk_size: 100
-        disk_type: pd-ssd
-        zone: {{google-zone}}
-        region: {{google-region}}
-  - task: gen_cluster
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-      PLATFORM: centos6
-  - task: gpinitsystem
-    file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: plcontainer
-    file: plcontainer_src/concourse/tasks/plcontainer_tests.yml
-    params:
-      platform: centos6
-    image: centos-gpdb-dev-6
-    input_mapping:
-      plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
-    on_success:
-      <<: *ccp_destroy
-  ensure:
-    <<: *set_failed
-
-- name: plcontainer_resgroup_test_centos6
-  plan:
-  - aggregate:
-    - get: plcontainer_src
-      passed:
-      - plcontainer_build_centos6
-    - get: gpdb_src
-    - get: gpdb_binary
-      resource: bin_gpdb_centos6
-    - get: ccp_src
-      passed: [plcontainer_build_python_image, plcontainer_build_r_image]
-    - get: centos-gpdb-dev-6
-    - get: plcontainer_pyclient_docker_image
-      resource: plcontainer_docker_image_centos_python
-      passed: [plcontainer_build_python_image]
-      trigger: true
-    - get: plcontainer_rclient_docker_image
-      resource: plcontainer_docker_image_centos_r
-      passed: [plcontainer_build_r_image]
-      trigger: true
-    - get: plcontainer_gpdb_centos6_build
-      passed: [plcontainer_build_centos6]
-      trigger: true
-  - put: terraform
-    params:
-      <<: *ccp_default_params
-      vars:
-        instance_type: n1-standard-4
-        PLATFORM: centos6
-        disk_size: 100
-        disk_type: pd-ssd
-        zone: {{google-zone}}
-        region: {{google-region}}
-  - task: gen_cluster
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-      PLATFORM: centos6
-  - task: gpinitsystem
-    file: ccp_src/ci/tasks/gpinitsystem.yml 
-  - task: plcontainer_resgroup
-    file: plcontainer_src/concourse/tasks/plcontainer_resgroup_tests.yml
-    params:
-      TEST_OS: centos6
-      platform: centos6
-    image: centos-gpdb-dev-6
-    input_mapping:
-      plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
-    on_success:
-      <<: *ccp_destroy
-  ensure:
-    <<: *set_failed
-
 - name: plcontainer_function_test_centos7
   plan:
   - aggregate:
@@ -447,7 +280,6 @@ jobs:
     - get: gpdb_binary
       resource: bin_gpdb_centos7
     - get: ccp_src
-      passed: [plcontainer_build_python_image, plcontainer_build_r_image]
     - get: centos-gpdb-dev-7
     - get: plcontainer_pyclient_docker_image
       resource: plcontainer_docker_image_centos_python
@@ -499,7 +331,6 @@ jobs:
     - get: gpdb_binary
       resource: bin_gpdb_centos7
     - get: ccp_src
-      passed: [plcontainer_build_python_image, plcontainer_build_r_image]
     - get: centos-gpdb-dev-7
     - get: plcontainer_pyclient_docker_image
       resource: plcontainer_docker_image_centos_python
@@ -551,9 +382,9 @@ jobs:
     - get: plcontainer_src
     - get: gpdb_src
     - get: gpdb_binary
-      resource: bin_gpdb_centos6
+      resource: bin_gpdb_centos7
     - get: ccp_src
-    - get: centos-gpdb-dev-6
+    - get: centos-gpdb-dev-7
     - get: data-science-bundle
     - get: python
       trigger: true
@@ -585,7 +416,7 @@ jobs:
     params:
       platform: centos7
       language: python
-    image: centos-gpdb-dev-6
+    image: centos-gpdb-dev-7
     input_mapping:
       plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
   - put: plcontainer_docker_image_centos_python
@@ -602,9 +433,9 @@ jobs:
     - get: plcontainer_src
     - get: gpdb_src
     - get: gpdb_binary
-      resource: bin_gpdb_centos6
+      resource: bin_gpdb_centos7
     - get: ccp_src
-    - get: centos-gpdb-dev-6
+    - get: centos-gpdb-dev-7
     - get: data-science-bundle
     - get: r
       trigger: true
@@ -634,7 +465,7 @@ jobs:
     params:
       platform: centos7
       language: r
-    image: centos-gpdb-dev-6
+    image: centos-gpdb-dev-7
     input_mapping:
       plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
   - put: plcontainer_docker_image_centos_r

--- a/concourse/release-pipeline.yml
+++ b/concourse/release-pipeline.yml
@@ -5,11 +5,9 @@
 groups:
 - name: plcontainer
   jobs:
-  - plcontainer_build_centos6
   - plcontainer_build_centos7
   - plcontainer_build_python_image
   - plcontainer_build_r_image
-  - plcontainer_function_test_centos6
   - plcontainer_function_test_centos7
 
 ################################################################################
@@ -144,12 +142,6 @@ resources:
 
 # Docker images
 
-- name: centos-gpdb-dev-6
-  type: docker-image
-  source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: '6-gcc6.2-llvm3.7'
-
 - name: centos-gpdb-dev-7
   type: docker-image
   source:
@@ -157,15 +149,6 @@ resources:
     tag: 7-gcc6.2-llvm3.7
 
 # S3 Input and intermediate binaries
-
-- name: plr_gpdb5_centos6_build
-  type: s3
-  source:
-    bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: release/gpdb5/plr/plr-2.3.2-gp5-rhel6-x86_64.gppkg
 - name: plr_gpdb5_centos7_build
   type: s3
   source:
@@ -266,15 +249,6 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: {{bin_gpdb_centos7_versioned_file}}
 
-- name: bin_gpdb_centos6
-  type: s3
-  source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: {{bin_gpdb_centos_versioned_file}}
-
 - name: plcontainer_gpdb_centos7_build
   type: s3
   source:
@@ -283,15 +257,6 @@ resources:
     access_key_id: {{bucket-access-key-id}}
     secret_access_key: {{bucket-secret-access-key}}
     regexp: release_candidate/gpdb5/plcontainer/plcontainer-(.*)-rhel7-x86_64.gppkg
-
-- name: plcontainer_gpdb_centos6_build
-  type: s3
-  source:
-    bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: release_candidate/gpdb5/plcontainer/plcontainer-(.*)-rhel6-x86_64.gppkg
 
 - name: plcontainer_gpdb_centos7_build_release
   type: s3
@@ -317,29 +282,6 @@ resources:
 jobs:
 
 # Build PL/Container GP Package
-- name: plcontainer_build_centos6
-  max_in_flight: 4
-  plan:
-  - aggregate:
-    - get: bin_gpdb_centos6
-    - get: gpdb_src
-    - get: plcontainer_src
-      trigger: true
-    - get: centos-gpdb-dev-6
-    - get: plr
-      resource: plr_gpdb5_centos6_build
-  - task: plcontainer_gpdb_build
-    file: plcontainer_src/concourse/tasks/plcontainer_build.yml
-    image: centos-gpdb-dev-6
-    params:
-      DEV_RELEASE: release
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-  - aggregate:
-    - put: plcontainer_gpdb_centos6_build
-      params:
-        file: plcontainer_gpdb_build/plcontainer*.gppkg
-
 - name: plcontainer_build_centos7
   max_in_flight: 4
   plan:
@@ -362,55 +304,6 @@ jobs:
     - put: plcontainer_gpdb_centos7_build
       params:
         file: plcontainer_gpdb_build/plcontainer*.gppkg
-
-
-- name: plcontainer_function_test_centos6
-  plan:
-  - aggregate:
-    - get: plcontainer_src
-    - get: gpdb_src
-    - get: gpdb_binary
-      resource: bin_gpdb_centos6
-      trigger: true
-    - get: ccp_src
-    - get: centos-gpdb-dev-6
-    - get: plcontainer_pyclient_docker_image
-      resource: plcontainer_docker_image_centos_python_release
-      trigger: true
-    - get: plcontainer_rclient_docker_image
-      resource: plcontainer_docker_image_centos_r_release
-      trigger: true
-    - get: plcontainer_gpdb_centos6_build_release
-      trigger: true
-  - put: terraform
-    params:
-      <<: *ccp_default_params
-      vars:
-        instance_type: n1-standard-4
-        PLATFORM: centos6
-        disk_size: 100
-        disk_type: pd-ssd
-        zone: {{google-zone}}
-        region: {{google-region}}
-  - task: gen_cluster
-    file: ccp_src/ci/tasks/gen_cluster.yml
-    params:
-      <<: *ccp_gen_cluster_default_params
-      PLATFORM: centos6
-  - task: gpinitsystem
-    file: ccp_src/ci/tasks/gpinitsystem.yml
-  - task: plcontainer
-    file: plcontainer_src/concourse/tasks/plcontainer_tests.yml
-    params:
-      platform: centos6
-    image: centos-gpdb-dev-6
-    input_mapping:
-      plcontainer_gpdb_build: plcontainer_gpdb_centos6_build_release
-    on_success:
-      <<: *ccp_destroy
-  ensure:
-    <<: *set_failed
-
 
 - name: plcontainer_function_test_centos7
   plan:
@@ -469,7 +362,7 @@ jobs:
     - get: gpdb_binary
       resource: bin_gpdb_centos6
     - get: ccp_src
-    - get: centos-gpdb-dev-6
+    - get: centos-gpdb-dev-7
     - get: data-science-bundle
     - get: python
       resource: python-gp5
@@ -499,7 +392,7 @@ jobs:
       DEV_RELEASE: release
       platform: centos7
       language: python
-    image: centos-gpdb-dev-6
+    image: centos-gpdb-dev-7
     input_mapping:
       plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
   - put: plcontainer_docker_image_centos_python
@@ -517,9 +410,9 @@ jobs:
       trigger: true
     - get: gpdb_src
     - get: gpdb_binary
-      resource: bin_gpdb_centos6
+      resource: bin_gpdb_centos7
     - get: ccp_src
-    - get: centos-gpdb-dev-6
+    - get: centos-gpdb-dev-7
     - get: data-science-bundle
     - get: r
       resource: r-gp5
@@ -548,7 +441,7 @@ jobs:
       DEV_RELEASE: release
       platform: centos7
       language: r
-    image: centos-gpdb-dev-6
+    image: centos-gpdb-dev-7
     input_mapping:
       plcontainer_gpdb_build: plcontainer_gpdb_centos6_build
   - put: plcontainer_docker_image_centos_r

--- a/src/sqlhandler.c
+++ b/src/sqlhandler.c
@@ -301,6 +301,10 @@ plcMessage *handle_sql_message(plcMsgSQL *msg, plcConn *conn, plcProcInfo *pinfo
 						} else {
 							/* A bit heavy to populate plcTypeInfo. */
 							fill_type_info(NULL, plc_plan->argOids[i], pexecType);
+							if (pexecType->type == PLC_DATA_ARRAY || pexecType->type == PLC_DATA_UDT)
+							{
+								plc_elog(ERROR, "Array and Udt are not supported for execute with plan");
+							}
 							values[i] = pexecType->infunc(msg->args[i].data.value, pexecType);
 							nulls[i] = ' ';
 						}

--- a/tests/expected/function_python_gpdb5.out
+++ b/tests/expected/function_python_gpdb5.out
@@ -56,3 +56,9 @@ CREATE OR REPLACE FUNCTION pybadudtarr2() RETURNS test_type4[] AS $$
 return [ {'a': 1, 'b': [2, 3], 'c': ['foo', 'bar']},
          {'a': 4, 'b': [5, 'f'], 'c': ['a', 'b']} ]
 $$ LANGUAGE plcontainer;
+CREATE OR REPLACE FUNCTION exec_prepare_array_error(x int4[]) RETURNS text AS $$
+# container: plc_python_shared
+plan = plpy.prepare("SELECT ($1)", ["int4[]"])
+plpy.execute(plan, [x])
+return "should not reach here"
+$$ language plcontainer;

--- a/tests/expected/test_python_gpdb5.out
+++ b/tests/expected/test_python_gpdb5.out
@@ -78,3 +78,5 @@ DETAIL:  Cannot find key 'c' in result dictionary for converting it into UDT
 select pybadudtarr2();
 ERROR:  PL/Container client exception occurred:
 DETAIL:  Exception occurred transforming result object to float8
+select exec_prepare_array_error(array[1,2,3]::int4[]);
+ERROR:  plcontainer: Array and Udt are not supported for execute with plan (sqlhandler.c:306)

--- a/tests/sql/function_python_gpdb5.sql
+++ b/tests/sql/function_python_gpdb5.sql
@@ -66,3 +66,10 @@ CREATE OR REPLACE FUNCTION pybadudtarr2() RETURNS test_type4[] AS $$
 return [ {'a': 1, 'b': [2, 3], 'c': ['foo', 'bar']},
          {'a': 4, 'b': [5, 'f'], 'c': ['a', 'b']} ]
 $$ LANGUAGE plcontainer;
+
+CREATE OR REPLACE FUNCTION exec_prepare_array_error(x int4[]) RETURNS text AS $$
+# container: plc_python_shared
+plan = plpy.prepare("SELECT ($1)", ["int4[]"])
+plpy.execute(plan, [x])
+return "should not reach here"
+$$ language plcontainer;

--- a/tests/sql/test_python_gpdb5.sql
+++ b/tests/sql/test_python_gpdb5.sql
@@ -14,3 +14,4 @@ select * from unnest(pytestudt14( array[(1,1,'a'), (2,2,'b'), (3,3,'c')]::test_t
 select * from pytestudt15( array[(1,1,'a'), (2,2,'b'), (3,3,'c')]::test_type3[] );
 select pybadudtarr();
 select pybadudtarr2();
+select exec_prepare_array_error(array[1,2,3]::int4[]);


### PR DESCRIPTION
1. Array/UDT for SPI prepare argument are not supported,
   fix crash when such arguments are passed into prepare
   statement. Now an error will be thrown to notify users
   that such argument types are not supported.
2. Regression tests updated.
3. Update pipeline and remove unused tests