### PR TITLE
Dockerfile.python3.ubuntu: reduce size

### DIFF
--- a/dockerfiles/Dockerfile.python3.ubuntu
+++ b/dockerfiles/Dockerfile.python3.ubuntu
@@ -1,7 +1,6 @@
-FROM ubuntu:18.04
+FROM python:3.7-slim-buster
 
 RUN mkdir -p /clientdir
-RUN apt update && apt install -y python3.7 python3.7-dev python3-pip
 
 ENV PATH "${PATH:+:${PATH}}"
 ENV LD_LIBRARY_PATH "/usr/lib/python3.7${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"


### PR DESCRIPTION
Hello!
1. Switched image to `python:3.7-slim-buster` - this image is smaller than `ubuntu:18.04` and python 3.7 already installed
2. Removed `python3.7-dev` installation. It looks like this package came from developing process and not needed to run pyclient.

As result the image size will be 2-3x smaller.

Please use https://hub.docker.com/_/python/ images in the future. For example there is `python:3.7-alpine` image - it's extremely small image. But it requires to build packages during install using `pip` and more fine-tunning the image so I choose the `slim-buster` for this pull request.