### PR TITLE
Information collector now support to show currently running UDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ DATA_built = $(MGMTDIR)/sql/plcontainer_install.sql $(MGMTDIR)/sql/plcontainer_u
 FILES = $(shell find $(SRCDIR) -not -path "*client*" -type f -name "*.c")
 OBJS = $(foreach FILE,$(FILES),$(subst .c,.o,$(FILE)))
 
+PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK = $(libpq)
+
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ endif
 # FIXME: We might need a configure script to handle below checks later.
 # See https://github.com/greenplum-db/plcontainer/issues/322
 
-# Plcontainer version
-PLCONTAINER_VERSION = $(shell git describe --tags)
+# Plcontainer version, show the nearest version and ignore the following commit
+PLCONTAINER_VERSION = $(shell git describe --abbrev=0)
 ifeq ($(PLCONTAINER_VERSION),)
   $(error can not determine the plcontainer version)
 else

--- a/management/sql/plcontainer_gp--1.0.0.sql
+++ b/management/sql/plcontainer_gp--1.0.0.sql
@@ -17,7 +17,7 @@ AS '$libdir/plcontainer', 'refresh_plcontainer_config'
 LANGUAGE C VOLATILE;
 
 CREATE TYPE container_summary_type AS ("SEGMENT_ID" text, "CONTAINER_ID" text, "UP_TIME" text, "OWNER" text, "MEMORY_USAGE(KB)" text);
-CREATE TYPE container_info_type AS ("SEGMENT_ID" text, "CONTAINER_ID" text, "UP_TIME" text, "OWNER" text, "MEMORY_USAGE(KB)" text, "CPU_USAGE");
+CREATE TYPE container_info_type AS ("SEGMENT_ID" text, "CONTAINER_ID" text, "UP_TIME" text, "OWNER" text, "MEMORY_USAGE(KB)" text, "CPU_USAGE" text, "UDF INFO" text);
 
 CREATE OR REPLACE FUNCTION plcontainer_containers_summary() RETURNS setof container_summary_type
 AS '$libdir/plcontainer', 'containers_summary'
@@ -50,7 +50,7 @@ CREATE OR REPLACE VIEW plcontainer_refresh_config as
 
 CREATE OR REPLACE VIEW plcontainer_containers as 
       WITH gpdbtmpa AS (SELECT (plcontainer_containers_info(gp_segment_id)) AS gpdbtmpb FROM (select gp_segment_id
-           from gp_dist_random('pg_namespace')
+           from gp_dist_random('gp_id')
            group by 1
       )  tmptbl) 
       SELECT (gpdbtmpb::container_info_type).* FROM gpdbtmpa union all 

--- a/management/sql/plcontainer_gp--1.0.0.sql
+++ b/management/sql/plcontainer_gp--1.0.0.sql
@@ -24,8 +24,12 @@ AS '$libdir/plcontainer', 'containers_summary'
 LANGUAGE C VOLATILE;
 
 
-CREATE OR REPLACE FUNCTION plcontainer_containers_info(dbid int4) RETURNS setof container_info_type
+CREATE OR REPLACE FUNCTION plcontainer_containers_info() RETURNS setof container_info_type
 AS '$libdir/plcontainer', 'list_running_containers'
+LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION plcontainer_containers() RETURNS setof container_info_type
+AS '$libdir/plcontainer', 'collect_running_containers'
 LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE VIEW plcontainer_show_config as
@@ -48,10 +52,3 @@ CREATE OR REPLACE VIEW plcontainer_refresh_config as
     union all
     select -1, plcontainer_refresh_local_config(false);
 
-CREATE OR REPLACE VIEW plcontainer_containers as 
-      WITH gpdbtmpa AS (SELECT (plcontainer_containers_info(gp_segment_id)) AS gpdbtmpb FROM (select gp_segment_id
-           from gp_dist_random('gp_id')
-           group by 1
-      )  tmptbl) 
-      SELECT (gpdbtmpb::container_info_type).* FROM gpdbtmpa union all 
-      select * from plcontainer_containers_info(-1) ;

--- a/src/containers.c
+++ b/src/containers.c
@@ -35,6 +35,7 @@
 #include "common/messages/messages.h"
 #include "plc_configuration.h"
 #include "containers.h"
+#include "plc_container_info.h"
 #include "plc_backend_api.h"
 
 
@@ -152,9 +153,9 @@ static void cleanup_atexit_callback() {
 	cleanup_uds(uds_fn_for_cleanup);
 	free(uds_fn_for_cleanup);
     /* Remove entry from shm */
-    del_containerid_entry(dockerid);
-    free(dockerid);
-    dockerid = NULL;
+    del_containerid_entry(dockerid_for_cleanup);
+    free(dockerid_for_cleanup);
+    dockerid_for_cleanup = NULL;
 	uds_fn_for_cleanup = NULL;
 }
 

--- a/src/containers.c
+++ b/src/containers.c
@@ -52,6 +52,7 @@ typedef struct {
 static volatile int containers_init = 0;
 static volatile container_t* volatile containers;
 static char *uds_fn_for_cleanup;
+static char *dockerid_for_cleanup;
 
 static void init_containers();
 
@@ -150,6 +151,10 @@ static void cleanup_uds(char *uds_fn) {
 static void cleanup_atexit_callback() {
 	cleanup_uds(uds_fn_for_cleanup);
 	free(uds_fn_for_cleanup);
+    /* Remove entry from shm */
+    del_containerid_entry(dockerid);
+    free(dockerid);
+    dockerid = NULL;
 	uds_fn_for_cleanup = NULL;
 }
 
@@ -180,6 +185,8 @@ static void cleanup(char *dockerid, char *uds_fn) {
 			/* use network TCP/IP, no need to clean up uds file */
 			uds_fn_for_cleanup = NULL;
 		}
+        /*Dup container id for clean purpose*/
+        dockerid_for_cleanup = strdup(dockerid);
 #ifdef HAVE_ATEXIT
 		atexit(cleanup_atexit_callback);
 #else
@@ -336,6 +343,23 @@ plcConn *get_container_conn(const char *runtime_id) {
 		if (containers[i].runtimeid != NULL &&
 		    strcmp(containers[i].runtimeid, runtime_id) == 0) {
 			return containers[i].conn;
+		}
+	}
+
+	return NULL;
+}
+
+char *get_container_id(const char *runtime_id)
+{
+   	size_t i;
+	if (containers_init == 0) {
+		init_containers();
+	}
+
+	for (i = 0; i < MAX_CONTAINER_NUMBER; i++) {
+		if (containers[i].runtimeid != NULL &&
+		    strcmp(containers[i].runtimeid, runtime_id) == 0) {
+			return containers[i].dockerid;
 		}
 	}
 

--- a/src/containers.h
+++ b/src/containers.h
@@ -27,4 +27,6 @@ plcConn *start_backend(runtimeConfEntry *conf);
 /* Function deletes all the containers */
 void delete_containers(void);
 
+char *get_container_id(const char *runtime_id);
+
 #endif /* PLC_CONTAINERS_H */

--- a/src/plc_configuration.h
+++ b/src/plc_configuration.h
@@ -66,5 +66,4 @@ runtimeConfEntry *plc_get_runtime_configuration(char *id);
 bool plc_check_user_privilege(char *users);
 
 char *get_sharing_options(runtimeConfEntry *conf, int container_slot, bool *has_error, char **uds_dir);
-
 #endif /* PLC_CONFIGURATION_H */

--- a/src/plc_container_info.c
+++ b/src/plc_container_info.c
@@ -617,9 +617,9 @@ add_containerid_entry(char *dockerid, char *udf)
         return;
     }
     /* Copy the data into hashmap entry */
-    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);
     cid[31] = '\0';
-    
+
     LWLockAcquire(plc_lw_lock, LW_EXCLUSIVE);
 
     cidentry = hash_search(udf_container_id_map, (void *)cid, HASH_ENTER, &found);
@@ -640,9 +640,9 @@ replace_containerid_entry(char *dockerid, char *udf)
         return;
     }
     /* Copy the data into hashmap entry */
-    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);
     cid[31] = '\0';
-    
+
     LWLockAcquire(plc_lw_lock, LW_EXCLUSIVE);
 
     cidentry = hash_search(udf_container_id_map, (void *)cid, HASH_FIND, &found);
@@ -657,7 +657,7 @@ void del_containerid_entry(char *dockerid)
     char cid[PREFIX_CONTAINER_ID_LENGTH];
 
     /* Copy the data into hashmap entry */
-    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);
     cid[31] = '\0';
 
     if (udf_container_id_map == NULL)

--- a/src/plc_container_info.h
+++ b/src/plc_container_info.h
@@ -13,7 +13,25 @@
 #include <json-c/json.h>
 #include "plcontainer.h"
 
+
+struct UdfContainerIdMap
+{
+    char container_id[32];
+    char udf_name[224];
+};
+typedef struct UdfContainerIdMap UdfContainerIdMap;
+
 Datum containers_summary(PG_FUNCTION_ARGS);
 Datum list_running_containers(PG_FUNCTION_ARGS);
+
+void plcontainer_shmem_startup(void);
+
+void init_plcontainer_shmem(void);
+
+void add_containerid_entry(char *dockerid, char *udf);
+
+UdfContainerIdMap* find_containerid_entry(char *dockerid);
+
+void del_containerid_entry(char *dockerid);
 
 #endif /* PLC_CONTAINER_INFO_H */

--- a/src/plc_container_info.h
+++ b/src/plc_container_info.h
@@ -30,6 +30,8 @@ void init_plcontainer_shmem(void);
 
 void add_containerid_entry(char *dockerid, char *udf);
 
+void replace_containerid_entry(char *dockerid, char *udf);
+
 void del_containerid_entry(char *dockerid);
 
 #endif /* PLC_CONTAINER_INFO_H */

--- a/src/plc_container_info.h
+++ b/src/plc_container_info.h
@@ -30,8 +30,6 @@ void init_plcontainer_shmem(void);
 
 void add_containerid_entry(char *dockerid, char *udf);
 
-UdfContainerIdMap* find_containerid_entry(char *dockerid);
-
 void del_containerid_entry(char *dockerid);
 
 #endif /* PLC_CONTAINER_INFO_H */

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -348,8 +348,11 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 			/* TODO: We could only remove this backend when error occurs. */
 			DeleteBackendsWhenError = true;
 			conn = start_backend(runtime_conf_entry);
-            add_containerid_entry(get_container_id(runtime_id), PLy_procedure_name(proc));
+			add_containerid_entry(get_container_id(runtime_id), PLy_procedure_name(proc));
 			DeleteBackendsWhenError = false;
+		} else {
+			/* Connection existed, only need update the udf name */
+			replace_containerid_entry(get_container_id(runtime_id), PLy_procedure_name(proc));
 		}
 
 		pfree(runtime_id);

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -151,8 +151,8 @@ _PG_init(void) {
 							 NULL,
 							 NULL,
 							 NULL);
-	//if (enable_cid)
-	init_plcontainer_shmem();
+	if (enable_cid)
+		init_plcontainer_shmem();
 
 	on_proc_exit(plcontainer_cleanup, 0);
 	explicit_subtransactions = NIL;
@@ -355,8 +355,6 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 			replace_containerid_entry(get_container_id(runtime_id), PLy_procedure_name(proc));
 		}
 
-		pfree(runtime_id);
-
 		DeleteBackendsWhenError = true;
 		if (conn != NULL) {
 			int res;
@@ -442,6 +440,9 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 	plcontainer_abort_open_subtransactions(save_subxact_level);
 
 	DeleteBackendsWhenError = false;
+
+	replace_containerid_entry(get_container_id(runtime_id), "Waiting for Query");
+	pfree(runtime_id);
 	return result;
 }
 

--- a/src/plcontainer.c
+++ b/src/plcontainer.c
@@ -83,6 +83,15 @@ static char * PLy_procedure_name(plcProcInfo *proc);
 
 static volatile bool DeleteBackendsWhenError;
 
+/* Monitoring */
+
+static HTAB *udf_container_id_map = NULL;
+LWLock	   *plc_lw_lock;
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+#define MAX_UDF_ENTRIES 256
+#define PREFIX_CONTAINER_ID_LENGTH 32
+static bool enable_cid = false;
+
 /*
  * Currently active plpython function
  */
@@ -135,9 +144,156 @@ _PG_init(void) {
                                 plcontainer_backend_type_assign_hook,
                                 NULL);
 
+	DefineCustomBoolVariable("plcontainer.enable_function_collection",
+							 "Collect current running function in container",
+							 NULL,
+							 &enable_cid,
+							 false,
+							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+    init_plcontainer_shmem();
 	on_proc_exit(plcontainer_cleanup, 0);
 	explicit_subtransactions = NIL;
 	inited = true;
+}
+
+Size
+PLContainerShmemSize(void)
+{
+	Size		size = 0;
+
+	size = add_size(size, hash_estimate_size(MAX_UDF_ENTRIES, sizeof(UdfContainerIdMap)));
+	return size;
+}
+
+static void
+init_lwlocks(void)
+{
+	LWLockPadded *base;
+	base = GetNamedLWLockTranche("plcontainer_locks");
+	plc_lw_lock = &base[0].lock;
+}
+/*
+ * 	Allocate and initialize plcontainer-related shared memory
+ */
+void
+plcontainer_shmem_startup(void)
+{
+	bool		found;
+	HASHCTL		hash_ctl;
+
+	if (prev_shmem_startup_hook)
+		(*prev_shmem_startup_hook)();
+
+	udf_container_id_map = NULL;
+
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
+	init_lwlocks();
+
+	memset(&hash_ctl, 0, sizeof(hash_ctl));
+	hash_ctl.keysize = PREFIX_CONTAINER_ID_LENGTH;
+	hash_ctl.entrysize =  sizeof(UdfContainerIdMap);
+	hash_ctl.hash = string_hash;
+
+	udf_container_id_map = ShmemInitHash("blackmap whose quota limitation is reached",
+									INIT_DISK_QUOTA_BLACK_ENTRIES,
+									MAX_DISK_QUOTA_BLACK_ENTRIES,
+									&hash_ctl,
+									HASH_ELEM | HASH_FUNCTION);
+
+	LWLockRelease(AddinShmemInitLock);
+}
+
+void
+init_plcontainer_shmem(void)
+{
+	/*
+	 * Request additional shared resources.  (These are no-ops if we're not in
+	 * the postmaster process.)  We'll allocate or attach to the shared
+	 * resources in pgss_shmem_startup().
+	 */
+	RequestAddinShmemSpace(DiskQuotaShmemSize());
+	RequestNamedLWLockTranche("plcontainer_locks", 1);
+
+	/*
+	 * Install startup hook to initialize our shared memory.
+	 */
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = plcontainer_shmem_startup;
+}
+
+void
+add_containerid_entry(char *dockerid, char *udf)
+{
+    bool found;
+    UdfContainerIdMap *cidentry;
+    char cid[PREFIX_CONTAINER_ID_LENGTH];
+
+    if (udf_container_id_map == NULL)
+    {
+        return;
+    }
+    /* Copy the data into hashmap entry */
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    cid[31] = '\0';
+    
+    LWLockAcquire(plc_lw_lock, LW_EXCLUSIVE);
+
+    cidentry = hash_search(udf_container_id_map, (void *)cid, HASH_ENTER, &found);
+    strncpy(cidentry->udf_name, udf, 224 - 1);
+    cidentry->udf_name[223] = '\0';
+	LWLockRelease(plc_lw_lock);
+}
+
+void del_containerid_entry(char *dockerid)
+{
+    bool found;
+    char cid[PREFIX_CONTAINER_ID_LENGTH];
+
+    /* Copy the data into hashmap entry */
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    cid[31] = '\0';
+
+    if (udf_container_id_map == NULL)
+    {
+        return;
+    }
+
+    LWLockAcquire(plc_lw_lock, LW_EXCLUSIVE);
+
+    hash_search(udf_container_id_map, (void *)cid, HASH_REMOVE, &found);
+
+	LWLockRelease(plc_lw_lock);
+}
+
+UdfContainerIdMap* find_containerid_entry(char *dockerid)
+{
+    bool found;
+    char cid[PREFIX_CONTAINER_ID_LENGTH];
+    UdfContainerIdMap *cidentry = NULL;
+
+    /* Copy the data into hashmap entry */
+    strncpy(cid, dockerid, PREFIX_CONTAINER_ID_LENGTH - 1);   
+    cid[31] = '\0';
+
+    if (udf_container_id_map == NULL)
+    {
+        return NULL;
+    }
+
+    cidentry = hash_search(udf_container_id_map, (void *)cid, HASH_FOUND, &found);
+
+    if (found)
+    {
+        return cidentry;
+    }
+
+    return NULL;
 }
 
 static bool
@@ -329,6 +485,7 @@ static plcProcResult *plcontainer_get_result(FunctionCallInfo fcinfo,
 			/* TODO: We could only remove this backend when error occurs. */
 			DeleteBackendsWhenError = true;
 			conn = start_backend(runtime_conf_entry);
+            add_containerid_entry(get_container_id(runtime_id), PLy_procedure_name(proc));
 			DeleteBackendsWhenError = false;
 		}
 

--- a/src/plcontainer.h
+++ b/src/plcontainer.h
@@ -13,4 +13,5 @@
 
 /* entrypoint for all plcontainer procedures */
 Datum plcontainer_call_handler(PG_FUNCTION_ARGS);
+
 #endif /* PLC_PLCONTAINER_H */


### PR DESCRIPTION
1. Information collector can show currently the name of UDF, which is running in the container
2. The plcontainer must be loaded in shared_preload_library GUC
3. Guc ` plcontainer.enable_function_collection` must set to TURE to enable the UDF collector