### PR TITLE
set TCP_NODELAY=yes to speed our use case

### DIFF
--- a/src/common/comm_connectivity.c
+++ b/src/common/comm_connectivity.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <sys/un.h>
 #include <sys/socket.h>
+#include <netinet/tcp.h>
 #include <libgen.h>
 
 #include "comm_utils.h"
@@ -421,6 +422,9 @@ plcConn *plcConnect_inet(int port) {
 	tv.tv_sec = 0;
 	tv.tv_usec = 500000;
 	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *) &tv, sizeof(struct timeval));
+
+	int one = 1;
+	setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(int));
 
 	result = plcConnInit(sock);
 	init_pplan_slots(result);


### PR DESCRIPTION
flush ASAP after any TCP send.
plcontainer has a buffer over TCP layer when server sends a message to client, we want client get this message immediately.

-----

localhost: 18.934s->19.238s (+1.5%)
not test on remotehost yet, but I think it will work.

