### PR TITLE
gpu: correct the docker version requirement

### DIFF
--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -31,7 +31,11 @@ static char *plc_docker_socket = "/var/run/docker.sock";
 
 // URL prefix specifies Docker API version
 static char *plc_docker_version_127 = "http:/v1.27";
-static char *plc_docker_version_140 = "http:/v1.40"; // support after moby v19.03
+// GPU basic support after moby v19.03 (2019-7) API version v1.40
+// GPU with out privilege support when using NVIDIA/libnvidia-container v1.10 (2020.5) with API version v1.40
+// need to use NVIDIA/libnvidia-container to enable non-privilege container
+// NVIDIA/container-config (2019-11~2021-11) or something before libnvidia-container does not support non-privilege
+static char *plc_docker_version_140 = "http:/v1.40";
 
 static char *default_log_dirver = "journald";
 


### PR DESCRIPTION
libnvidia-container add the cap here
https://github.com/NVIDIA/libnvidia-container/blob/395fd41701117121f1fd04ada01e1d7e006a37ae/src/cli/configure.c#L225-L246

the permission mapping here 
https://github.com/NVIDIA/libnvidia-container/blob/395fd41701117121f1fd04ada01e1d7e006a37ae/src/nvc_internal.h#L97-L130

and remove the cap here
https://github.com/NVIDIA/libnvidia-container/blob/395fd41701117121f1fd04ada01e1d7e006a37ae/src/nvc_ldcache.c#L169-L180

the container boot with CAP_SYS_ADMIN, after the boot finished, CAP_SYS_ADMIN was removed.

after 2020-05, the non-privileged container with GPU support by default.

plcontainer does not modify the default setting if the user runs with `NVIDIA/container-config` or another GPU shim. still can be a privileged container.