### PR TITLE
fix: release pipeline is publishing wrong intermediates

### DIFF
--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -242,9 +242,11 @@ plan:
 - in_parallel:
     steps:
 
-#@ for conf in confs:
+#@ for i, conf in enumerate(confs):
     - do:
       - get: #@ conf["res_intermediates_bin"]
+        passed:
+          - #@ passed_jobs[i]
         params:
           unpack: true
       - put: #@ conf["release_bin"]


### PR DESCRIPTION
**Same problem as https://github.com/greenplum-db/diskquota/pull/221**

Release pipeline is publishing wrong intermediates

"get" without "passed" will retrieve the latest content from a resource
which is not expected release. Especially the release and dev pipelines
share the intermediates bucket.

- Add passed the "get" step in the "exit_release" job, to make sure the
resource version generated from previous job will be consumed in this
job.