### PR TITLE
fix rel bucket and gppkg name

### DIFF
--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -50,7 +50,7 @@ res_intermediates_bin:  #@ inter_bin_name("bin_plcontainer_gpdb6_ubuntu18_interm
 os: ubuntu18.04
 container_name_suffix_python: #@ container_name_suffix_python
 container_name_suffix_r: #@ container_name_suffix_r
-release_bin: bin_plcontainer_gpdb6_ubuntu18_intermediates
+release_bin: bin_plcontainer_gpdb6_ubuntu18_release
 #@ end
 
 #! Job config for bundle release

--- a/package/Pack.cmake
+++ b/package/Pack.cmake
@@ -26,7 +26,7 @@ set(CPACK_RPM_SPEC_MORE_DEFINE
 
 include(CPack)
 
-set(PACK_NAME ${CMAKE_PROJECT_NAME}-${VERSION}-${DISTRO_NAME}_${CMAKE_SYSTEM_PROCESSOR})
+set(PACK_NAME ${CMAKE_PROJECT_NAME}-${VERSION}-gp${GP_MAJOR_VERSION}-${DISTRO_NAME}_${CMAKE_SYSTEM_PROCESSOR})
 # expecting filename of form %{name}-%{version}-%{release}.%{arch}.rpm
 # See gppkg's package.py
 set(RPM_NAME ${CMAKE_PROJECT_NAME}-${VERSION}.${CMAKE_SYSTEM_PROCESSOR})


### PR DESCRIPTION
- ubuntu rel was using the wrong bucket
- follow the current gppkg release name rule, put GP_MAJOR_VERSION
  into the file name.
