### PR TITLE
ci: switch gp binary to release-candidate for release build

### DIFF
--- a/concourse/pipeline/job_def.lib.yml
+++ b/concourse/pipeline/job_def.lib.yml
@@ -144,6 +144,7 @@ config:
   params:
     CONTAINER_NAME_SUFFIX_PYTHON: #@ conf["container_name_suffix_python"]
     CONTAINER_NAME_SUFFIX_R: #@ conf["container_name_suffix_r"]
+    ARTIFACT_TYPE: #@ "Debug" if conf["res_gpdb_bin"].endswith("_debug") else "Release"
   run:
     path: plcontainer_src/concourse/scripts/entry.sh
     args:

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -176,52 +176,40 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.debug.tar.gz
-# gpdb7
 - name: bin_gpdb7_rocky8_debug
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/main/server-rc-(.*)-rocky8_x86_64.debug.tar.gz
-- name: bin_gpdb7_rhel8_debug
-  type: gcs
-  source:
-    bucket: pivotal-gpdb-concourse-resources-prod
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rhel8_x86_64.debug.tar.gz
+
 # Latest release candidates, no fault-injector, no assertion:
 # --disable-debug-extensions --disable-tap-tests --enable-ic-proxy
+# for the version string regexp: match every version but not {6,7}.99. .99 used for test
 - name: bin_gpdb6_centos7
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-centos6.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-rhel8.tar.gz
 - name: bin_gpdb6_ubuntu18
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb6/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
-# gpdb7
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-ubuntu18.04.tar.gz
 - name: bin_gpdb7_rocky8
   type: gcs
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rocky8_x86_64.tar.gz
-- name: bin_gpdb7_rhel8
-  type: gcs
-  source:
-    bucket: pivotal-gpdb-concourse-resources-prod
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/main/server-rc-(.*)-rhel8_x86_64.tar.gz
+    regexp: server/release-candidates/gpdb7/greenplum-db-server-7\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-rhel8.tar.gz
 
 # For uploading every build to gcs gppkg
 - name: bin_plcontainer_gpdb6_rhel7_intermediates

--- a/concourse/pipeline/res_def.yml
+++ b/concourse/pipeline/res_def.yml
@@ -191,7 +191,7 @@ resources:
   source:
     bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-centos6.tar.gz
+    regexp: server/release-candidates/gpdb6/greenplum-db-server-6\.([0-9]|([1-8][0-9])|(9[0-8]))\.\d{1,2}-.*-centos7.tar.gz
 - name: bin_gpdb6_rhel8
   type: gcs
   source:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,12 @@
 include(${CMAKE_SOURCE_DIR}/cmake/Regress.cmake)
 
+list(APPEND REGRESS_OPTS "--dbname=${TEST_DB_NAME}")
+if("$ENV{ARTIFACT_TYPE}" STREQUAL "Release")
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/tests_using_faultinjector.txt EXCLUDE_TESTS)
+    string(STRIP ${EXCLUDE_TESTS} EXCLUDE_TESTS)
+    list(APPEND REGRESS_OPTS "--exclude-tests=${EXCLUDE_TESTS}")
+endif()
+
 RegressTarget_Add(testpy
     INIT_FILE
     ${CMAKE_CURRENT_SOURCE_DIR}/init_file
@@ -8,8 +15,7 @@ RegressTarget_Add(testpy
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/pl_schedule_py
-    REGRESS_OPTS
-    --dbname=${TEST_DB_NAME}
+    REGRESS_OPTS ${REGRESS_OPTS}
     REGRESS_ENV PL_TESTDB=${TEST_DB_NAME})
 
 RegressTarget_Add(testpy2
@@ -20,8 +26,7 @@ RegressTarget_Add(testpy2
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/pl_schedule_py2
-    REGRESS_OPTS
-    --dbname=${TEST_DB_NAME}
+    REGRESS_OPTS ${REGRESS_OPTS}
     REGRESS_ENV PL_TESTDB=${TEST_DB_NAME})
 
 RegressTarget_Add(testr
@@ -32,8 +37,7 @@ RegressTarget_Add(testr
     RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
     DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/data
     SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/pl_schedule_r
-    REGRESS_OPTS
-    --dbname=${TEST_DB_NAME}
+    REGRESS_OPTS ${REGRESS_OPTS}
     REGRESS_ENV PL_TESTDB=${TEST_DB_NAME})
 
 add_custom_target(installcheck)
@@ -49,8 +53,7 @@ if(CONTAINER_NAME_SUFFIX_PYTHON MATCHES ".*_b")
         RESULTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/results
         DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/regress/data
         SCHEDULE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/regress/pl_schedule_py_bundle
-        REGRESS_OPTS
-        --dbname=${TEST_DB_NAME}
+        REGRESS_OPTS ${REGRESS_OPTS}
         REGRESS_ENV PL_TESTDB=${TEST_DB_NAME})
     add_dependencies(installcheck testpy_bundle)
 endif()

--- a/tests/tests_using_faultinjector.txt
+++ b/tests/tests_using_faultinjector.txt
@@ -1,0 +1,1 @@
+faultinject_python


### PR DESCRIPTION
the binary in `server/published` has --enable-debug-extensions. but we do not want this. switch to `server/release-candidates.

but a binary with version 7.99.99 in release candidates was used for releng test. so some long regex string exists in this PR to filter out this version.

and skip faultinject test when for release build, faultinject is not enabled in gpdb release version.