### PR TITLE
management: select python3 if no python or python2 available

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -1,4 +1,20 @@
-#!/usr/bin/env python
+#!/bin/sh
+
+''':'
+PYTHON=$(head -n 1 "$GPHOME/lib/python/gppylib/gpcatalog.py" 2> /dev/null | cut -d ' ' -f 2)
+
+if [ -z $PYTHON ]; then
+    PYTHON=$(which python3 2> /dev/null || which python 2> /dev/null || which python2 2> /dev/null)
+fi
+
+if [ -z $PYTHON ]; then
+    echo "no python3 or python2 detected"
+    exit 1
+fi
+
+exec $PYTHON $0 "$@"
+exit $?
+''' #'''
 
 #------------------------------------------------------------------------------
 #

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ''':'
-PYTHON=$(head -n 1 "$GPHOME/lib/python/gppylib/gpcatalog.py" 2> /dev/null | cut -d ' ' -f 2)
+PYTHON=$(head -n 1 "$GPHOME/lib/python/gppylib/gplog.py" 2> /dev/null | cut -d ' ' -f 2)
 
 if [ -z $PYTHON ]; then
     PYTHON=$(which python3 2> /dev/null || which python 2> /dev/null || which python2 2> /dev/null)


### PR DESCRIPTION
how does it work?

`management/bin/plcontainer` is both a shell script and a python script.

first this script will use the shell part to find python3 or python2. then use python and exec syscall to boot self.

the header `''':'` and `'''#'''` is some empty string and comment syntax in bash and python