### PR TITLE
Fix REL pipeline by removing version file for py3 image

### DIFF
--- a/dockerfiles/Dockerfile.python37.ubuntu1804
+++ b/dockerfiles/Dockerfile.python37.ubuntu1804
@@ -7,7 +7,5 @@ RUN python3 get-pip.py
 RUN pip3.7 --no-cache install cmake
 
 ENV LD_LIBRARY_PATH "/usr/lib/python3.7:${LD_LIBRARY_PATH}"
-# add the version to the image
-ADD VERSION_bundle_ubuntu1804_py37 VERSION
 RUN mkdir -p /clientdir
 WORKDIR /clientdir


### PR DESCRIPTION
The basic python37.ubuntu1804 image is for building py3 client only. The
image itself won't be released. Due to the structure change by #674, the
missing version file caused build failure.
