### PR TITLE
fix: UnicodeDecodeError: 'ascii' codec error for ubuntu2204 python39

### DIFF
--- a/dockerfiles/Dockerfile.python39.ubuntu2204
+++ b/dockerfiles/Dockerfile.python39.ubuntu2204
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
 # this is to fix UnicodeDecodeError: 'ascii' codec for pymc and other packages for
 # UnicodeDecodeError Error, can check link: https://github.com/docker-library/python/issues/13
-ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN apt update && \
     apt-get install -y --force-yes --no-install-recommends software-properties-common gpg-agent && \

--- a/dockerfiles/Dockerfile.python39.ubuntu2204
+++ b/dockerfiles/Dockerfile.python39.ubuntu2204
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
+# this is to fix UnicodeDecodeError: 'ascii' codec for pymc and other packages for
+# UnicodeDecodeError Error, can check link: https://github.com/docker-library/python/issues/13
+ENV LANG C.UTF-8
 
 RUN apt update && \
     apt-get install -y --force-yes --no-install-recommends software-properties-common gpg-agent && \


### PR DESCRIPTION
error for pymc package

error:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2365: ordinal not in range(128)

because this is in docker container side, so we need to fix this in images building