### PR TITLE
Fix flaky error in test_configuration

### DIFF
--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -598,7 +598,7 @@ int plc_docker_delete_container(const char *name) {
 int plc_docker_list_container(char **result, int dbid) {
 	plcCurlBuffer *response = NULL;
 	char *url = "/containers/json?all=1&filters=";
-	char *param = "{\"label\":[\"dbid=%d\"]}";
+	char *param = "{\"label\":[\"dbid=%d\"], \"status\":[\"created\", \"restarting\", \"running\"]}";
 	char *body = NULL;
 	int res = 0;
 


### PR DESCRIPTION
When running test case 'test_configuration', sometimes it will fail.

There is the error message when calling
`plcontainer_containers_summary`:
 ERROR:  plcontainer: Fail to get docker container state: Failed to get
 container xxxx state, return code: 404, detail: {"message":"No such
 container: xxxx"} (plc_container_info.c:525)

So, maybe there is a such situation:
1. `plcontainer_containers_summary` call c function `containers_summary`
2. `containers_summary` will call `plc_docker_list_container`.
3. `plc_docker_list_container` will list all docker containers like
   `docker containers ls -al` without filter status.
4. If `plc_docker_list_container` get a container which is removing, and
   then plcontainer will use docker api to get information of this
   removing container, but maybe the container has been removed at that
   time, so docker return error.

To solve this problem, we should filter containers status in
`plc_docker_list_container` only `created`, `restarting`, `running`
containers should be returned.

To reproduce:
1. add a sleep in `containers_summary` after `plc_docker_list_container`,
   for example, sleep 2 seconds
2. open a session with `psql xx`
3. run a plcontainer udf
4. exit session
5. open a session again and call `plcontainer_containers_summary` quickly.

