### PR TITLE
management: fix runtime-edit crash in py3

### DIFF
--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -483,7 +483,7 @@ def get_file_md5(file):
     h = hashlib.md5()
     f = open(file, 'r')
     for l in f:
-        h.update(l)
+        h.update(l.encode('utf-8'))
     f.close()
     return h.digest()
 

--- a/management/bin/plcontainer
+++ b/management/bin/plcontainer
@@ -480,12 +480,8 @@ def get_file_md5(file):
     of bytes and cannot be printed directly to the screen or log file
     without converting to hex.
     '''
-    h = hashlib.md5()
-    f = open(file, 'r')
-    for l in f:
-        h.update(l.encode('utf-8'))
-    f.close()
-    return h.digest()
+    with open(file, 'rb') as f:
+        return hashlib.md5(f.read()).digest()
 
 
 def copy_file_to_tmp(host, file):


### PR DESCRIPTION
fllow up https://github.com/greenplum-db/plcontainer/pull/665

```
Traceback (most recent call last):
  File "/home/sa/GPDB/plcontainer/./management/bin/plcontainer", line 974, in main
    changed = edit_file(tmp_file, options.editor)
  File "/home/sa/GPDB/plcontainer/./management/bin/plcontainer", line 647, in edit_file
    h1 = get_file_md5(filename)
  File "/home/sa/GPDB/plcontainer/./management/bin/plcontainer", line 486, in get_file_md5
    h.update(l)
TypeError: Strings must be encoded before hashing
```