### PR TITLE
fix cmake error

### DIFF
--- a/dockerfiles/Dockerfile.python27.ubuntu
+++ b/dockerfiles/Dockerfile.python27.ubuntu
@@ -3,9 +3,9 @@ FROM ubuntu:18.04
 EXPOSE 8080
 RUN mkdir -p /clientdir
 RUN apt update && apt install -y python2.7 python-pip python-dev gcc g++ make
-# for easily install the latest cmake
-RUN pip install -U pip
-RUN pip install cmake==3.27.7
+
+ADD https://github.com/Kitware/CMake/releases/download/v3.26.5/cmake-3.26.5-linux-x86_64.sh /cmake.sh
+RUN sh /cmake.sh --prefix=/usr/local/ --exclude-subdir --skip-license && rm /cmake.sh
 
 ENV PATH "${PATH:+:${PATH}}"
 ENV LD_LIBRARY_PATH "/usr/lib/python2.7${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"

--- a/dockerfiles/Dockerfile.python27.ubuntu
+++ b/dockerfiles/Dockerfile.python27.ubuntu
@@ -5,7 +5,7 @@ RUN mkdir -p /clientdir
 RUN apt update && apt install -y python2.7 python-pip python-dev gcc g++ make
 # for easily install the latest cmake
 RUN pip install -U pip
-RUN pip install cmake
+RUN pip install cmake==3.27.7
 
 ENV PATH "${PATH:+:${PATH}}"
 ENV LD_LIBRARY_PATH "/usr/lib/python2.7${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"


### PR DESCRIPTION
CMake 3.27.9 in [pypi](https://pypi.org/project/cmake/#history) broke python2 support, but 3.27.7 is ok.