### PR TITLE
Remove resource group warning.

### DIFF
--- a/tests/regress/expected/test_wrong_config_python_7.out
+++ b/tests/regress/expected/test_wrong_config_python_7.out
@@ -89,7 +89,6 @@ ERROR:  plcontainer: container cpu share couldn't be equal or less than 0, curre
 Test wrong resource group id which contain nondigit
 select plcontainer_refresh_local_config(true);
 ERROR:  invalid input syntax for type integer: "plgroup"
-WARNING:  plcontainer: Greenplum7 resource group integration is not supported is this PL/Container
 \! $(pwd)/test_wrong_config.sh 22
 Test good format (but it still fails since the configuration (image/command) is not legal)
 select plcontainer_refresh_local_config(true);


### PR DESCRIPTION
Remove resource group warning.

plcontainer can works with gpdb7 now, so we can remove those warning in tests.

CI: https://dev2.ci.gpdb.pivotal.io/teams/gp-extensions/pipelines/dev.plcontainer.rdu_fix_pipeline.rdu