### PR TITLE
adpat plcontainer for gpdb resouce group

### DIFF
--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -404,7 +404,7 @@ int plc_docker_create_container(
 	 */
 
 	if (conf->resgroupOid != InvalidOid && backend->tag == PLC_BACKEND_DOCKER) {
-#if PG_VERSION_NUM >= 120000 // gpdb7 removed RESGROUP_MEMORY_AUDITOR_CGROUP
+#if GP_VERSION_NUM >= 70000 // gpdb7 removed RESGROUP_MEMORY_AUDITOR_CGROUP
 		if (Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_GROUP_V2)
 			snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/%s/%d",gp_resource_group_cgroup_parent, conf->resgroupOid);
 		else

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -16,6 +16,7 @@
 #include "plc_backend_api.h"
 #include "plc_configuration.h"
 #include "utils/resgroup.h"
+#include "utils/resource_manager.h"
 #ifndef PLC_PG
   #include "cdb/cdbvars.h"
 #endif
@@ -404,7 +405,10 @@ int plc_docker_create_container(
 
 	if (conf->resgroupOid != InvalidOid && backend->tag == PLC_BACKEND_DOCKER) {
 #if PG_VERSION_NUM >= 120000 // gpdb7 removed RESGROUP_MEMORY_AUDITOR_CGROUP
-		snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/%s/%d",gp_resource_group_cgroup_parent, conf->resgroupOid);
+		if (Gp_resource_manager_policy == RESOURCE_MANAGER_POLICY_GROUP_V2)
+			snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/%s/%d",gp_resource_group_cgroup_parent, conf->resgroupOid);
+		else
+			snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/gpdb/%d", conf->resgroupOid);
 #else
 		snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/gpdb/%d", conf->resgroupOid);
 #endif

--- a/src/plc_docker_api.c
+++ b/src/plc_docker_api.c
@@ -15,6 +15,7 @@
 #include "plc_docker_api.h"
 #include "plc_backend_api.h"
 #include "plc_configuration.h"
+#include "utils/resgroup.h"
 #ifndef PLC_PG
   #include "cdb/cdbvars.h"
 #endif
@@ -402,7 +403,11 @@ int plc_docker_create_container(
 	 */
 
 	if (conf->resgroupOid != InvalidOid && backend->tag == PLC_BACKEND_DOCKER) {
-		snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/gpdb/%d",conf->resgroupOid);
+#if PG_VERSION_NUM >= 120000 // gpdb7 removed RESGROUP_MEMORY_AUDITOR_CGROUP
+		snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/%s/%d",gp_resource_group_cgroup_parent, conf->resgroupOid);
+#else
+		snprintf(cgroupParent, RES_GROUP_PATH_MAX_LENGTH, "/gpdb/%d", conf->resgroupOid);
+#endif
 	}
 
 	if (conf->ndevicerequests > 0) {


### PR DESCRIPTION
adpat plcontainer for gpdb resouce group.

There is a guc `gp_resouce_group_cgroup_parent` to get gpdb cgroup root after https://github.com/greenplum-db/gpdb/pull/16738 merged, plcontainer should use this guc to get gpdb cgroup root.