### PR TITLE
try to fix flaky case: test_configuration

### DIFF
--- a/tests/regress/expected/clean_docker.out
+++ b/tests/regress/expected/clean_docker.out
@@ -1,0 +1,3 @@
+-- start_ignore
+\! docker kill $(docker ps -q)
+-- end_ignore

--- a/tests/regress/pl_schedule_py
+++ b/tests/regress/pl_schedule_py
@@ -53,3 +53,6 @@ test: test_config_remote_docker
 
 # Drop the extension - need to be last
 test: drop
+
+# clean docker containers
+test: clean_docker

--- a/tests/regress/pl_schedule_py2
+++ b/tests/regress/pl_schedule_py2
@@ -21,3 +21,6 @@ test: uda_python2
 
 # Drop the extension - need to be last
 test: drop
+
+# clean docker containers
+test: clean_docker

--- a/tests/regress/pl_schedule_r
+++ b/tests/regress/pl_schedule_r
@@ -12,3 +12,6 @@ test: uda_r
 
 # Drop the extension - need to be last
 test: drop
+
+# clean docker containers
+test: clean_docker

--- a/tests/regress/sql/clean_docker.sql
+++ b/tests/regress/sql/clean_docker.sql
@@ -1,0 +1,3 @@
+-- start_ignore
+\! docker kill $(docker ps -q)
+-- end_ignore


### PR DESCRIPTION
In `test_configuration` test case, there is a sql:
`select count(*) from plcontainer_containers_summary() WHERE "UP_TIME" LIKE 'Up %';`
always failed.

plcontainer runs multiple test schedule sequentially, and when execute `select count(*) from plcontainer_containers_summary() WHERE "UP_TIME" LIKE 'Up %';` , there are maybe some containers created by previous schedule still exists.
For example:
```
+ cmake --build . --target installcheck

(using postmaster on Unix socket, port 6000)

============== dropping database "testr"              ==============

NOTICE:  database "testr" does not exist, skipping

DROP DATABASE

============== creating database "testr"              ==============

CREATE DATABASE

ALTER DATABASE

============== checking optimizer status              ==============

Optimizer enabled. Using optimizer answer files whenever possible

============== checking gp_resource_manager status    ==============

Resource group disabled. Using default answer files

============== running regression test queries        ==============

test schema                   ... ok (5.11 sec)  (diff:2.42 sec)

parallel group (2 tests):  function_r_gpdb6 function_r

     function_r               ... ok (0.49 sec)  (diff:0.10 sec)

     function_r_gpdb6         ... ok (0.10 sec)  (diff:0.08 sec)

test test_r                   ... ok (23.59 sec)  (diff:0.17 sec)

test test_r_gpdb6             ... ok (3.79 sec)  (diff:0.07 sec)

test uda_r                    ... ok (3.10 sec)  (diff:0.08 sec)

test drop                     ... ok (0.16 sec)  (diff:0.08 sec)


=====================

 All 7 tests passed. 

=====================


Built target testr

(using postmaster on Unix socket, port 6000)

============== dropping database "testpy"             ==============

NOTICE:  database "testpy" does not exist, skipping

DROP DATABASE

============== creating database "testpy"             ==============

CREATE DATABASE

ALTER DATABASE

============== checking optimizer status              ==============

Optimizer enabled. Using optimizer answer files whenever possible

============== checking gp_resource_manager status    ==============

Resource group disabled. Using default answer files

============== running regression test queries        ==============

test schema                   ... ok (1.39 sec)  (diff:0.08 sec)

test test_configuration       ... FAILED (43.43 sec)  (diff:0.20 sec)
```

check the output of `test_configuration`:
```
-- start_ignore
\! docker ps -a
CONTAINER ID   IMAGE             COMMAND                  CREATED         STATUS         PORTS     NAMES
936d3343d727   r.alpine:latest   "/clientdir/rclient.…"   4 seconds ago   Up 3 seconds             jolly_varahamihira
6e381cc3c9dd   r.alpine:latest   "/clientdir/rclient.…"   6 seconds ago   Up 5 seconds             gifted_edison
95b3a7cb93a4   r.alpine:latest   "/clientdir/rclient.…"   6 seconds ago   Up 5 seconds             friendly_poitras
fdc354d87943   r.alpine:latest   "/clientdir/rclient.…"   6 seconds ago   Up 5 seconds             cool_payne
-- end_ignore
select count(*) from plcontainer_containers_summary() WHERE "UP_TIME" LIKE 'Up %';
 count
-------
     1
(1 row)
```

so we should clean the containers when schedule end.

CI: https://dev2.ci.gpdb.pivotal.io/teams/gp-extensions/pipelines/dev.plcontainer.rdu_fix_flaky.rdu